### PR TITLE
feat(client): add news store and restructure api types

### DIFF
--- a/client/app/(landing)/article/data.ts
+++ b/client/app/(landing)/article/data.ts
@@ -1,4 +1,4 @@
-import { Article } from "@/lib/api/auth/types";
+import { Article } from "@/lib/api/news/types";
 
 // dummy data, should be replaced with actual data from API
 export const articleData: Article = {

--- a/client/lib/api/auth/types.ts
+++ b/client/lib/api/auth/types.ts
@@ -1,31 +1,3 @@
-export interface Author {
-  name: string;
-  imageUrl: string;
-}
-
-export interface RelatedArticle {
-  id: string;
-  title: string;
-  category: string;
-  image: string;
-  href: string;
-}
-
-export interface Article {
-  id: string | number;
-  country: string;
-  category: string;
-  title: string;
-  subtitle: string;
-  author: Author;
-  featuredImageUrl: string;
-  createdAt: string; // ISO Date string
-  views: number;
-  content: string;
-  topics: string[];
-  relatedArticles: RelatedArticle[];
-}
-
 export interface User {
   id: number;
   email: string;

--- a/client/lib/api/news/store.ts
+++ b/client/lib/api/news/store.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { Article, NewsStore } from "./types";
+
+/**
+ * News API hook that handles fetching news data from the api
+ * @example
+ * // This is a react component.
+ * export function NewsCard() {
+ *  const { articles, fetchArticles } = useNews();
+ *  return (
+ *    <>
+ *    </>
+ *  );
+ * }
+ */
+export const useNews = create<NewsStore>((set) => ({
+  // Articles that are fetched are stored here.
+  articles: [],
+
+  // Fetches data from the api.
+  // Doesn't require authentication.
+  // TODO: Implement cache to prevent unnecessary api calls.
+  fetchArticles: async () => {
+    const dummyArticles: Article[] = [];
+
+    // TODO: replace this with actual fetch when the api is ready.
+    set({
+      articles: dummyArticles
+    });
+  }
+}));

--- a/client/lib/api/news/types.ts
+++ b/client/lib/api/news/types.ts
@@ -1,0 +1,37 @@
+export interface Author {
+  name: string;
+  imageUrl: string;
+}
+
+export interface RelatedArticle {
+  id: string;
+  title: string;
+  category: string;
+  image: string;
+  href: string;
+}
+
+export interface Article {
+  id: string | number;
+  country: string;
+  category: string;
+  title: string;
+  subtitle: string;
+  author: Author;
+  featuredImageUrl: string;
+  createdAt: string; // ISO Date string
+  views: number;
+  content: string;
+  topics: string[];
+  relatedArticles: RelatedArticle[];
+}
+
+export interface NewsState {
+  articles: Article[];
+}
+
+export interface NewsActions {
+  fetchArticles: () => Promise<void>;
+}
+
+export interface NewsStore extends NewsState, NewsActions { }


### PR DESCRIPTION
### Summary
This PR introduces `client/lib/api/news`. An API that handles fetching and caching data from the server.

### Implementation
* Created `client/lib/api/news` which contains the following:
  * `types.ts` - News-related types
  * `store.ts` - News API state management

### Testing
TODO: Will be connected to `client/app` once the API is live and ready.

- Create news store and type definitions.
- Moved shared types from auth to news directory.
- Update imports in app to reflect type changes.