### PR TITLE
Server/feat/admin routes user article revise

### DIFF
--- a/server/app/Http/Controllers/Api/AuthController.php
+++ b/server/app/Http/Controllers/Api/AuthController.php
@@ -7,9 +7,41 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use OpenApi\Attributes as OA;
 
 class AuthController extends Controller
 {
+    #[OA\Post(
+        path: "/api/login",
+        operationId: "authLogin",
+        summary: "Log in a user",
+        description: "Authenticates a user with email and password and returns a Sanctum token.",
+        tags: ["Authentication"],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ["email", "password"],
+                properties: [
+                    new OA\Property(property: "email", type: "string", format: "email", example: "admin@example.com"),
+                    new OA\Property(property: "password", type: "string", format: "password", example: "password")
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "Successful login",
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: "access_token", type: "string", example: "1|abcdef12345..."),
+                        new OA\Property(property: "token_type", type: "string", example: "Bearer")
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: "Invalid login details"),
+            new OA\Response(response: 422, description: "Validation error")
+        ]
+    )]
     public function login(Request $request)
     {
         $request->validate([
@@ -19,7 +51,7 @@ class AuthController extends Controller
 
         $user = User::where('email', $request->email)->first();
 
-        if (! $user || ! Hash::check($request->password, $user->password)) {
+        if (!$user || !Hash::check($request->password, $user->password)) {
             return response()->json([
                 'message' => 'Invalid login details'
             ], 401);
@@ -33,6 +65,26 @@ class AuthController extends Controller
         ]);
     }
 
+    #[OA\Post(
+        path: "/api/logout",
+        operationId: "authLogout",
+        summary: "Log out the authenticated user",
+        description: "Revokes the current user's access token.",
+        security: [['sanctum' => []]],
+        tags: ["Authentication"],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "Successfully logged out",
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: "message", type: "string", example: "Logged out successfully")
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: "Unauthenticated")
+        ]
+    )]
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
@@ -42,6 +94,22 @@ class AuthController extends Controller
         ]);
     }
 
+    #[OA\Get(
+        path: "/api/user",
+        operationId: "getAuthenticatedUser",
+        summary: "Get authenticated user details",
+        description: "Returns the details of the currently authenticated user.",
+        security: [['sanctum' => []]],
+        tags: ["Authentication"],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "User details retrieved successfully",
+                content: new OA\JsonContent(type: "object")
+            ),
+            new OA\Response(response: 401, description: "Unauthenticated")
+        ]
+    )]
     public function user(Request $request)
     {
         return response()->json($request->user());

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -14,21 +14,25 @@ class Article extends Model
 
     protected $fillable = [
         'title',
+        'original_title',
         'summary',
         'content',
         'image',
+        'category',
+        'country',
+        'source',
+        'original_url',
+        'keywords',
+        'topics',
         'status',
         'views_count',
-        // 'category_id', // REMOVED
-        'category', // ADDED
-        // 'user_id', // REMOVED
-        'country',
         'site_id',
         'custom_titles',
     ];
 
     protected $casts = [
         'custom_titles' => 'array',
+        'topics' => 'array',
     ];
 
     public function site()

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -48,19 +48,11 @@ Route::middleware('auth:sanctum')->group(function () {
 // Main feed endpoint with filtering
 Route::get('/article', [UserArticleController::class, 'feed']);
 
-// All articles with pagination
-Route::get('/articles', [UserArticleController::class, 'index']);
-
 // Single article by ID (UUID from Python)
 Route::get('/articles/{id}', [UserArticleController::class, 'show'])
     ->where('id', '[a-f0-9\-]{36}'); // UUID pattern
 
-// Articles by country (e.g., /api/articles/country/Philippines)
-Route::get('/articles/country/{country}', [UserArticleController::class, 'byCountry']);
 
-// Articles by category (e.g., /api/articles/category/Real Estate)
-Route::get('/articles/category/{category}', [UserArticleController::class, 'byCategory'])
-    ->where('category', '[a-zA-Z0-9\s]+'); // Allow spaces
 
 // Latest articles sorted by time
 Route::get('/latest', [UserArticleController::class, 'latest']);

--- a/server/storage/api-docs/api-docs.json
+++ b/server/storage/api-docs/api-docs.json
@@ -180,6 +180,14 @@
                         }
                     },
                     {
+                        "name": "topics",
+                        "in": "query",
+                        "description": "Filter by topics (comma-separated)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "page",
                         "in": "query",
                         "description": "The page number to retrieve",
@@ -257,6 +265,16 @@
                                         "description": "Default is 'pending review'",
                                         "type": "string",
                                         "example": "pending review"
+                                    },
+                                    "topics": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "real-estate",
+                                            "business"
+                                        ]
                                     }
                                 },
                                 "type": "object"
@@ -380,6 +398,16 @@
                                         "description": "JSON object mapping platform names to custom titles",
                                         "type": "object",
                                         "example": "{\"FilipinoHomes\": \"Custom Title 1\", \"Rent.ph\": \"Custom Title 2\"}"
+                                    },
+                                    "topics": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "real-estate",
+                                            "luxury"
+                                        ]
                                     }
                                 },
                                 "type": "object"
@@ -871,6 +899,136 @@
                 ]
             }
         },
+        "/api/login": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Log in a user",
+                "description": "Authenticates a user with email and password and returns a Sanctum token.",
+                "operationId": "authLogin",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "email",
+                                    "password"
+                                ],
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "admin@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "password"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful login",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "access_token": {
+                                            "type": "string",
+                                            "example": "1|abcdef12345..."
+                                        },
+                                        "token_type": {
+                                            "type": "string",
+                                            "example": "Bearer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid login details"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                }
+            }
+        },
+        "/api/logout": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Log out the authenticated user",
+                "description": "Revokes the current user's access token.",
+                "operationId": "authLogout",
+                "responses": {
+                    "200": {
+                        "description": "Successfully logged out",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Logged out successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/user": {
+            "get": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Get authenticated user details",
+                "description": "Returns the details of the currently authenticated user.",
+                "operationId": "getAuthenticatedUser",
+                "responses": {
+                    "200": {
+                        "description": "User details retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/redis-test": {
             "get": {
                 "tags": [
@@ -1043,64 +1201,19 @@
                 }
             }
         },
-        "/api/articles": {
-            "get": {
-                "tags": [
-                    "User: Articles"
-                ],
-                "summary": "Get all articles from Redis",
-                "description": "Returns paginated list of all articles stored in Redis.",
-                "operationId": "getAllArticles",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Max articles to return (1-100)",
-                        "schema": {
-                            "type": "integer",
-                            "default": 20
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for pagination",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/articles/{id}": {
             "get": {
                 "tags": [
                     "User: Articles"
                 ],
                 "summary": "Get a single article by ID",
-                "description": "Returns full article data from Redis.",
+                "description": "Returns full article data from the database.",
                 "operationId": "getArticleById",
                 "parameters": [
                     {
                         "name": "id",
                         "in": "path",
-                        "description": "Article UUID",
+                        "description": "Article ID (UUID)",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -1120,82 +1233,6 @@
                     },
                     "404": {
                         "description": "Article not found"
-                    }
-                }
-            }
-        },
-        "/api/articles/country/{country}": {
-            "get": {
-                "tags": [
-                    "User: Articles"
-                ],
-                "summary": "Get articles by country",
-                "description": "Returns articles filtered by country name (e.g., 'Philippines', 'Canada').",
-                "operationId": "getArticlesByCountry",
-                "parameters": [
-                    {
-                        "name": "country",
-                        "in": "path",
-                        "description": "Country name",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Max articles to return",
-                        "schema": {
-                            "type": "integer",
-                            "default": 20
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "404": {
-                        "description": "No articles found for country"
-                    }
-                }
-            }
-        },
-        "/api/articles/category/{category}": {
-            "get": {
-                "tags": [
-                    "User: Articles"
-                ],
-                "summary": "Get articles by category",
-                "description": "Returns articles filtered by category (e.g., 'Real Estate', 'Business').",
-                "operationId": "getArticlesByCategory",
-                "parameters": [
-                    {
-                        "name": "category",
-                        "in": "path",
-                        "description": "Category name",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Max articles to return",
-                        "schema": {
-                            "type": "integer",
-                            "default": 20
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "404": {
-                        "description": "No articles found for category"
                     }
                 }
             }
@@ -1357,6 +1394,10 @@
         {
             "name": "Admin: Sites",
             "description": "Admin: Sites"
+        },
+        {
+            "name": "Authentication",
+            "description": "Authentication"
         },
         {
             "name": "System",


### PR DESCRIPTION
### Summary
This PR adds the "Admin route" flow in the swagger allowing the frontend to sea the results through API routing.
### Implementation
Backend:
> Revise the API routes, still processing

Automated:
> Add swagger routes for admin.

Manual:
> Open localhost:8000/api/documentation for swagger routes.
> then check the /login routes inside the swagger.