### PR TITLE
refactor(client): add news types to getArticlesList

### DIFF
--- a/client/lib/api/news/service.ts
+++ b/client/lib/api/news/service.ts
@@ -1,6 +1,6 @@
 import api from "../axios";
 import { fake_landing_page_articles } from "./fake_data";
-import { Article, ArticleFilters, ArticlesListResponse, LandingPageArticlesResponse } from "./types";
+import { Article, ArticleFilters, ArticlesFeedResponse, ArticlesListResponse } from "./types";
 
 // Toggle this to true if you want to force mock data when API is down
 const FAKE = true;
@@ -9,27 +9,22 @@ const FAKE = true;
  * Returns Trending, Most Read (Latest), and Latest Global articles from Redis. 
  * Optionally filter by country, category, or search term.
  */
-export async function getLandingPageArticles(params?: ArticleFilters): Promise<LandingPageArticlesResponse> {
+export async function getArticlesList({ limit = 10, ...params }: ArticleFilters) {
+
   if (FAKE) {
     return fake_landing_page_articles;
   }
-  const response = await api.get<LandingPageArticlesResponse>("/article", { params });
+
+  const response = await api.get<ArticlesFeedResponse | ArticlesListResponse>("/article", {
+    params: {
+      // 10 limit
+      limit,
+      // everything else
+      ...params
+    }
+  });
   return response.data;
 }
-
-/**
- * Returns paginated list of articles stored in Redis in a mini format.
- * @param params.limit - Number of articles to return.
- * @param params.offset - Number of articles to skip.
- */
-export async function getArticlesList(params?: {
-  limit: number;
-  offset: number;
-}) {
-  const response = await api.get<ArticlesListResponse>("/articles", { params });
-  return response.data;
-}
-
 /**
  * Returns a single article by ID
  */
@@ -43,6 +38,7 @@ export async function getArticleById(id: string) {
     // Loose comparison for string/number id mismatch
     return allArticles.find(a => String(a.id) === String(id)) || allArticles[0];
   }
+
   const response = await api.get<Article>(`/articles/${id}`);
   return response.data;
 }

--- a/client/lib/api/news/types/model.ts
+++ b/client/lib/api/news/types/model.ts
@@ -21,7 +21,7 @@ export interface ArticleListItem {
 }
 
 export interface ArticleFilters {
-  mode?: "feed" | "list";
+  mode: "feed" | "list";
   search?: string;
   country?: string;
   category?: string;

--- a/client/lib/api/news/types/response.ts
+++ b/client/lib/api/news/types/response.ts
@@ -6,8 +6,6 @@ export interface ArticlesFeedResponse {
   latest_global: Article[];
 }
 
-export type LandingPageArticlesResponse = ArticlesFeedResponse;
-
 export interface ArticlesListResponse {
   data: ArticleListItem[];
   meta: {


### PR DESCRIPTION
### Summary
This PR refactors `getLandingPageArticles` into `getArticlesList` which is a function for gathering a list of articles.

### Implementation
* Renamed `getLandingPageArticles` into `getArticlesList`.
  * Made `params.mode` non-null so it must be set.
  * Added the types `ArticlesFeedResponse` and `ArticlesListResponse`.