### PR TITLE
feat(client): add admin settings page with change password modal

### DIFF
--- a/client/app/admin/settings/page.tsx
+++ b/client/app/admin/settings/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Lock, Save, Upload, User } from "lucide-react";
+import AdminPageHeader from "@/components/features/admin/shared/AdminPageHeader";
+import ChangePasswordModal from "@/components/features/admin/settings/ChangePasswordModal";
+import { FormInput, FormSelect } from "@/components/features/admin/shared/FormFields";
+
+export default function SettingsPage() {
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
+
+  const [formData, setFormData] = useState({
+    fullName: "Admin User",
+    username: "admin",
+    email: "admin@globalnews.com",
+    role: "Super Admin",
+    phone: "+971 50 123 4567",
+  });
+
+  const openFilePicker = () => fileInputRef.current?.click();
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      alert("Please select an image file.");
+      e.target.value = "";
+      return;
+    }
+
+    // Simple client-side preview (no backend upload yet)
+    const url = URL.createObjectURL(file);
+    setPhotoPreviewUrl(url);
+  };
+
+  const handleSaveSettings = () => {
+    alert("Settings saved successfully!");
+  };
+
+  return (
+    <div className="p-8 bg-[#f9fafb] min-h-screen">
+      <AdminPageHeader
+        title="Settings"
+        description="Manage your admin credentials"
+      />
+
+      <div className="space-y-8">
+        {/* Admin Credentials Section */}
+        <div className="bg-white rounded-[12px] border border-[#e5e7eb] p-8">
+          <div className="flex items-start gap-3 mb-8">
+            <div className="w-12 h-12 bg-[#dbeafe] rounded-[8px] flex items-center justify-center flex-shrink-0">
+              <User className="w-6 h-6 text-[#3b82f6]" />
+            </div>
+            <div>
+              <h2 className="text-[18px] font-bold text-[#111827] tracking-[-0.5px]">
+                Admin Credentials
+              </h2>
+              <p className="text-[14px] text-[#6b7280] tracking-[-0.5px]">
+                Manage your admin account information
+              </p>
+            </div>
+          </div>
+
+          {/* Profile Picture Section */}
+          <div className="flex items-center gap-6 mb-8 pb-8 border-b border-[#e5e7eb]">
+            <div className="relative">
+              <button
+                type="button"
+                onClick={openFilePicker}
+                className="w-24 h-24 bg-[#f3f4f6] rounded-full flex items-center justify-center overflow-hidden"
+                title="Upload photo"
+              >
+                {photoPreviewUrl ? (
+                  <img
+                    src={photoPreviewUrl}
+                    alt="Profile photo preview"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <User className="w-12 h-12 text-[#9ca3af]" />
+                )}
+              </button>
+
+              <button
+                type="button"
+                onClick={openFilePicker}
+                className="absolute bottom-0 right-0 w-8 h-8 bg-[#C10007] rounded-full flex items-center justify-center"
+                title="Upload photo"
+              >
+                <Upload className="w-4 h-4 text-white" />
+              </button>
+            </div>
+            <div>
+              <p className="text-[16px] font-bold text-[#111827] tracking-[-0.5px] mb-1">
+                {formData.fullName}
+              </p>
+              <p className="text-[14px] text-[#6b7280] tracking-[-0.5px] mb-3">
+                {formData.email}
+              </p>
+              <button
+                type="button"
+                onClick={openFilePicker}
+                className="flex items-center gap-2 px-4 py-2 text-[14px] text-[#C10007] border border-[#C10007] rounded-[6px] hover:bg-[#fef2f2] transition-colors tracking-[-0.5px] font-medium"
+              >
+                <Upload className="w-4 h-4" />
+                Upload Photo
+              </button>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handlePhotoChange}
+              />
+            </div>
+          </div>
+
+          {/* Form Fields */}
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                label="Full Name"
+                value={formData.fullName}
+                onChange={(e) => setFormData({ ...formData, fullName: e.target.value })}
+              />
+              <FormInput
+                label="Username"
+                value={formData.username}
+                onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+              />
+            </div>
+
+            <FormInput
+              label="Email Address"
+              type="email"
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            />
+
+            <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                label="Phone Number"
+                type="tel"
+                value={formData.phone}
+                onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+              />
+
+              {/* Timezone intentionally omitted (per request) */}
+              <FormSelect
+                label="Role"
+                value={formData.role}
+                onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+                options={[
+                  { value: "Super Admin", label: "Super Admin" },
+                  { value: "Admin", label: "Admin" },
+                  { value: "Editor", label: "Editor" },
+                  { value: "Viewer", label: "Viewer" },
+                ]}
+              />
+            </div>
+
+            <div className="pt-6 border-t border-[#e5e7eb]">
+              <button
+                onClick={() => setShowPasswordModal(true)}
+                className="flex items-center gap-2 px-5 py-2.5 text-[14px] text-[#3b82f6] border border-[#3b82f6] rounded-[8px] hover:bg-[#eff6ff] transition-colors tracking-[-0.5px] font-medium"
+              >
+                <Lock className="w-4 h-4" />
+                Change Password
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Appearance section intentionally omitted (per request) */}
+
+        {/* Save Button */}
+        <div className="flex justify-end">
+          <button
+            onClick={handleSaveSettings}
+            className="flex items-center gap-2 px-6 py-3 bg-[#C10007] text-white rounded-[8px] hover:bg-[#a10006] transition-colors text-[16px] font-medium tracking-[-0.5px]"
+          >
+            <Save className="w-4 h-4" />
+            Save Settings
+          </button>
+        </div>
+      </div>
+
+      <ChangePasswordModal isOpen={showPasswordModal} onClose={() => setShowPasswordModal(false)} />
+    </div>
+  );
+}
+
+

--- a/client/components/features/admin/layout/AdminSidebar.tsx
+++ b/client/components/features/admin/layout/AdminSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@/components/ui/sidebar";
-import { LayoutDashboard, FileText, BarChart3, Calendar, Settings, LogOut } from "lucide-react";
+import { LayoutDashboard, FileText, BarChart3, Calendar, Settings, LogOut, Users } from "lucide-react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -16,7 +16,32 @@ const SidebarItems = [
     title: "Articles",
     href: "/admin/articles",
     icon: FileText
-  }
+  },
+  // {
+  //   title: "Ads",
+  //   href: "/admin/ads",
+  //   icon: BarChart3
+  // },
+  // {
+  //   title: "Sites",
+  //   href: "/admin/sites",
+  //   icon: Users
+  // },
+  // {
+  //   title: "Calendar",
+  //   href: "/admin/calendar",
+  //   icon: Calendar
+  // },
+  // {
+  //   title: "Analytics",
+  //   href: "/admin/analytics",
+  //   icon: BarChart3
+  // },
+  // {
+  //   title: "Settings",
+  //   href: "/admin/settings",
+  //   icon: Settings
+  // }
 ]
 
 export default function AdminSidebar() {

--- a/client/components/features/admin/settings/ChangePasswordModal.tsx
+++ b/client/components/features/admin/settings/ChangePasswordModal.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff, Lock, X } from "lucide-react";
+
+interface ChangePasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProps) {
+  const [formData, setFormData] = useState({
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    if (formData.newPassword !== formData.confirmPassword) {
+      alert("New passwords do not match!");
+      return;
+    }
+    alert("Password changed successfully!");
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-[#00000066] flex items-center justify-center z-[110] p-4 animate-in fade-in duration-200">
+      <div className="bg-white rounded-[16px] shadow-[0px_25px_50px_0px_rgba(0,0,0,0.25)] w-full max-w-[500px] overflow-hidden animate-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="px-8 py-6 border-b border-[#e5e7eb] flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-[#dbeafe] rounded-[8px] flex items-center justify-center">
+              <Lock className="w-5 h-5 text-[#3b82f6]" />
+            </div>
+            <h2 className="text-[20px] font-bold text-[#111827] tracking-[-0.5px]">
+              Change Password
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-100 rounded-full transition-colors group"
+          >
+            <X className="w-5 h-5 text-[#6b7280] group-hover:text-[#111827]" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-8 py-6">
+          <div className="space-y-5">
+            {/* Current Password */}
+            <div>
+              <label className="block text-[14px] font-semibold text-[#111827] mb-2 tracking-[-0.5px]">
+                Current Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showCurrentPassword ? "text" : "password"}
+                  value={formData.currentPassword}
+                  onChange={(e) => setFormData({ ...formData, currentPassword: e.target.value })}
+                  placeholder="Enter current password"
+                  className="w-full px-4 py-3 pr-12 border border-[#d1d5db] rounded-[8px] text-[14px] text-[#111827] placeholder:text-[#9ca3af] focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:border-transparent tracking-[-0.5px]"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowCurrentPassword((v) => !v)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[#6b7280] hover:text-[#111827]"
+                >
+                  {showCurrentPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                </button>
+              </div>
+            </div>
+
+            {/* New Password */}
+            <div>
+              <label className="block text-[14px] font-semibold text-[#111827] mb-2 tracking-[-0.5px]">
+                New Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showNewPassword ? "text" : "password"}
+                  value={formData.newPassword}
+                  onChange={(e) => setFormData({ ...formData, newPassword: e.target.value })}
+                  placeholder="Enter new password"
+                  className="w-full px-4 py-3 pr-12 border border-[#d1d5db] rounded-[8px] text-[14px] text-[#111827] placeholder:text-[#9ca3af] focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:border-transparent tracking-[-0.5px]"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowNewPassword((v) => !v)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[#6b7280] hover:text-[#111827]"
+                >
+                  {showNewPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                </button>
+              </div>
+              <p className="text-[12px] text-[#6b7280] mt-2 tracking-[-0.5px]">
+                Password must be at least 8 characters long
+              </p>
+            </div>
+
+            {/* Confirm New Password */}
+            <div>
+              <label className="block text-[14px] font-semibold text-[#111827] mb-2 tracking-[-0.5px]">
+                Confirm New Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={formData.confirmPassword}
+                  onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
+                  placeholder="Re-enter new password"
+                  className="w-full px-4 py-3 pr-12 border border-[#d1d5db] rounded-[8px] text-[14px] text-[#111827] placeholder:text-[#9ca3af] focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:border-transparent tracking-[-0.5px]"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[#6b7280] hover:text-[#111827]"
+                >
+                  {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                </button>
+              </div>
+            </div>
+
+            {/* Password Requirements */}
+            <div className="bg-[#f9fafb] border border-[#e5e7eb] rounded-[8px] p-4">
+              <p className="text-[13px] font-semibold text-[#111827] mb-2 tracking-[-0.5px]">
+                Password Requirements:
+              </p>
+              <ul className="space-y-1 text-[12px] text-[#6b7280] tracking-[-0.5px]">
+                <li className="flex items-center gap-2">
+                  <span className="w-1 h-1 bg-[#6b7280] rounded-full" />
+                  At least 8 characters long
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="w-1 h-1 bg-[#6b7280] rounded-full" />
+                  Contains uppercase and lowercase letters
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="w-1 h-1 bg-[#6b7280] rounded-full" />
+                  Contains at least one number
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="w-1 h-1 bg-[#6b7280] rounded-full" />
+                  Contains at least one special character
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-[#e5e7eb] px-8 py-4 flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-5 py-2.5 text-[14px] text-[#6b7280] hover:text-[#111827] transition-colors tracking-[-0.5px] font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="flex items-center gap-2 px-5 py-2.5 bg-[#3b82f6] text-white rounded-[8px] hover:bg-[#2563eb] transition-colors text-[14px] font-medium tracking-[-0.5px]"
+          >
+            <Lock className="w-4 h-4" />
+            Change Password
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+


### PR DESCRIPTION
feat(client): add admin settings page with change password modal

### Summary
This PR adds an Admin Settings page for managing admin credentials and introduces a Change Password modal. It also updates the Admin sidebar menu configuration with placeholders for upcoming modules (Ads, Sites, Calendar, Analytics, Settings).

### Implementation
**Frontend:**
- **Settings Page**
  - Added `app/admin/settings/page.tsx` with admin credentials form UI (name, username, email, phone, role) and Save action.
  - Integrated shared `AdminPageHeader` and shared form fields (`FormInput`, `FormSelect`).
  - Added entry point to open the Change Password modal.
- **Change Password**
  - Added `components/features/admin/settings/ChangePasswordModal.tsx` with:
    - current/new/confirm password fields
    - show/hide password toggles
    - basic client-side validation (confirm password match)
- **Navigation (Admin Sidebar)**
  - Updated `components/features/admin/layout/AdminSidebar.tsx` to include commented menu items for Ads/Sites/Calendar/Analytics/Settings (future wiring).

### Testing
**Manual:**
1. Navigate to **Admin > Settings** (`/admin/settings`).
2. Verify the credentials form renders correctly.
3. Click **Change Password** and verify the modal opens/closes properly.
4. Enter mismatched new passwords and confirm validation triggers.
5. Enter matching passwords and confirm success flow triggers (alert + close).