### PR TITLE
Feat/site api key system

### DIFF
--- a/client/app/admin/sites/data.ts
+++ b/client/app/admin/sites/data.ts
@@ -10,6 +10,9 @@ export interface Site {
     requested: string;
     articles: number;
     monthlyViews: string;
+    contact_name?: string;
+    contact_email?: string;
+    apiKey?: string;
 }
 
 export const sitesData: Site[] = [

--- a/client/app/admin/sites/page.tsx
+++ b/client/app/admin/sites/page.tsx
@@ -192,6 +192,18 @@ export default function SitesPage() {
                                 setEditingSite(site as Site);
                                 setIsEditorOpen(true);
                             }}
+                            onRefreshKey={async (id) => {
+                                if (confirm(`Are you sure you want to regenerate the API key for ${site.name}? The old key will stop working immediately.`)) {
+                                    try {
+                                        const updatedSite = await import('@/lib/api/admin/sites').then(m => m.refreshSiteKey(id));
+                                        setSitesList(prev => prev.map(s => s.id === id ? updatedSite : s));
+                                        alert("API Key regenerated successfully.");
+                                    } catch (error) {
+                                        console.error("Failed to refresh key:", error);
+                                        alert("Failed to regenerate API Key.");
+                                    }
+                                }
+                            }}
                         />
                     ))
                 ) : (

--- a/client/components/features/admin/sites/SiteListItem.tsx
+++ b/client/components/features/admin/sites/SiteListItem.tsx
@@ -1,30 +1,42 @@
 "use client";
 
-import { Edit, Trash2, Link as LinkIcon } from 'lucide-react';
+import { Edit, Trash2, Link as LinkIcon, Key, RotateCw, Copy, Check } from 'lucide-react';
 import { Site } from "@/app/admin/sites/data";
 import StatusBadge from "@/components/features/admin/shared/StatusBadge";
+import { useState } from 'react';
 
 interface SiteListItemProps {
     site: Site;
     onEdit?: (site: Site) => void;
     onDelete?: (id: number) => void;
     onToggleStatus?: (id: number) => void;
+    onRefreshKey?: (id: number) => void;
 }
 
 /**
  * SiteListItem component for displaying a single site in the management list
  */
-export default function SiteListItem({ site, onEdit, onDelete, onToggleStatus }: SiteListItemProps) {
+export default function SiteListItem({ site, onEdit, onDelete, onToggleStatus, onRefreshKey }: SiteListItemProps) {
     const isActive = site.status === 'active';
+    const [showKey, setShowKey] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = () => {
+        if (site.apiKey) {
+            navigator.clipboard.writeText(site.apiKey);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    };
 
     return (
         <div className="bg-white border border-[#e5e7eb] rounded-[12px] p-6 hover:shadow-md transition-shadow">
             <div className="flex gap-6">
                 {/* Site Logo */}
                 <div className="w-[100px] h-[100px] rounded-[8px] overflow-hidden flex-shrink-0 bg-gray-100">
-                    <img 
-                        src={site.image} 
-                        alt={site.name} 
+                    <img
+                        src={site.image}
+                        alt={site.name}
                         className="w-full h-full object-cover"
                         onError={(e) => {
                             const target = e.target as HTMLImageElement;
@@ -45,8 +57,8 @@ export default function SiteListItem({ site, onEdit, onDelete, onToggleStatus }:
                             </div>
                             <div className="flex items-center gap-2 mb-2">
                                 <LinkIcon className="w-3.5 h-3.5 text-[#3b82f6]" />
-                                <a 
-                                    href={`https://${site.domain}`} 
+                                <a
+                                    href={`https://${site.domain}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="text-[13px] text-[#3b82f6] hover:underline tracking-[-0.5px]"
@@ -60,6 +72,40 @@ export default function SiteListItem({ site, onEdit, onDelete, onToggleStatus }:
                             <p className="text-[14px] text-[#6b7280] tracking-[-0.5px] mb-3 leading-relaxed">
                                 {site.description}
                             </p>
+
+                            {/* API Key Section */}
+                            <div className="flex items-center gap-2 mb-3 bg-gray-50 p-2 rounded-md border border-gray-100 w-fit">
+                                <Key className="w-3.5 h-3.5 text-gray-400" />
+                                <span className="text-[12px] font-medium text-gray-500 uppercase">API Key:</span>
+                                <code className="text-[12px] font-mono text-gray-700 max-w-[200px] truncate">
+                                    {showKey ? site.apiKey : '••••••••••••••••••••••••••••••••'}
+                                </code>
+                                <div className="flex items-center gap-1 ml-2">
+                                    <button
+                                        onClick={() => setShowKey(!showKey)}
+                                        className="text-[11px] text-blue-600 hover:underline"
+                                    >
+                                        {showKey ? 'Hide' : 'Show'}
+                                    </button>
+                                    <div className="h-3 w-[1px] bg-gray-300 mx-1"></div>
+                                    <button
+                                        onClick={handleCopy}
+                                        className="text-gray-400 hover:text-gray-600"
+                                        title="Copy API Key"
+                                    >
+                                        {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+                                    </button>
+                                    <div className="h-3 w-[1px] bg-gray-300 mx-1"></div>
+                                    <button
+                                        onClick={() => onRefreshKey?.(site.id)}
+                                        className="text-gray-400 hover:text-blue-600"
+                                        title="Regenerate API Key"
+                                    >
+                                        <RotateCw className="w-3.5 h-3.5" />
+                                    </button>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
 
@@ -97,11 +143,10 @@ export default function SiteListItem({ site, onEdit, onDelete, onToggleStatus }:
                 <div className="flex items-start gap-3">
                     <button
                         onClick={() => onToggleStatus?.(site.id)}
-                        className={`px-4 py-2 text-[13px] font-medium rounded-[6px] transition-colors tracking-[-0.5px] ${
-                            isActive
+                        className={`px-4 py-2 text-[13px] font-medium rounded-[6px] transition-colors tracking-[-0.5px] ${isActive
                                 ? 'text-[#C10007] hover:bg-red-50'
                                 : 'text-[#10b981] hover:bg-green-50'
-                        }`}
+                            }`}
                     >
                         {isActive ? 'Suspend' : 'Activate'}
                     </button>

--- a/client/lib/api/admin/sites.ts
+++ b/client/lib/api/admin/sites.ts
@@ -14,6 +14,7 @@ export interface Site {
     monthlyViews: string;
     contact_name?: string;
     contact_email?: string;
+    apiKey?: string;
 }
 
 export interface SitesResponse {
@@ -72,5 +73,13 @@ export async function toggleSiteStatus(id: number): Promise<void> {
  */
 export async function getSiteNames(): Promise<string[]> {
     const response = await api.get<string[]>('/admin/sites/names');
+    return response.data;
+}
+
+/**
+ * Refresh site API key
+ */
+export async function refreshSiteKey(id: number): Promise<Site> {
+    const response = await api.patch(`/admin/sites/${id}/refresh-key`);
     return response.data;
 }

--- a/server/app/Http/Controllers/Api/Admin/SiteController.php
+++ b/server/app/Http/Controllers/Api/Admin/SiteController.php
@@ -177,4 +177,20 @@ class SiteController extends Controller
 
         return response()->json($sites);
     }
+    /**
+     * Refresh the API Key for a site.
+     */
+    public function refreshKey(int $id): JsonResponse|SiteResource
+    {
+        $site = Site::find($id);
+
+        if (!$site) {
+            return response()->json(['error' => 'Site not found'], 404);
+        }
+
+        $site->api_key = \Illuminate\Support\Str::random(64);
+        $site->save();
+
+        return new SiteResource($site);
+    }
 }

--- a/server/app/Http/Controllers/Api/SiteContentController.php
+++ b/server/app/Http/Controllers/Api/SiteContentController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class SiteContentController extends Controller
+{
+    public function getArticles(Request $request)
+    {
+        // The site is already resolved by the Middleware
+        $site = $request->attributes->get('site');
+
+        // Fetch articles intended for this site
+        $articles = $site->articles()
+            ->where('status', 'published') // Ensure only published articles
+            ->orderBy('created_at', 'desc')
+            ->paginate(20);
+
+        return response()->json([
+            'site' => [
+                'name' => $site->site_name,
+                'url' => $site->site_url,
+                'description' => $site->site_description,
+            ],
+            'data' => $articles
+        ]);
+    }
+}

--- a/server/app/Http/Middleware/VerifySiteApiKey.php
+++ b/server/app/Http/Middleware/VerifySiteApiKey.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Models\Site;
+
+class VerifySiteApiKey
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $apiKey = $request->header('X-Site-Api-Key');
+        $origin = $request->header('Origin'); // Browser sends this for CORS requests
+
+        if (!$apiKey) {
+            return response()->json(['error' => 'API Key missing'], 401);
+        }
+
+        $site = Site::where('api_key', $apiKey)->where('site_status', 'active')->first();
+
+        if (!$site) {
+            return response()->json(['error' => 'Invalid or Suspended API Key'], 403);
+        }
+
+        // --- PRODUCTION ORIGIN VALIDATION ---
+        // In production, we ensure the request comes from the registered site_url
+        if (app()->environment('production') && $origin) {
+            $cleanSiteUrl = str_replace(['http://', 'https://', 'www.'], '', strtolower($site->site_url));
+            $cleanOrigin = str_replace(['http://', 'https://', 'www.'], '', strtolower($origin));
+
+            // Basic check: Origin should contain or match the registered site domain
+            if (!str_contains($cleanOrigin, $cleanSiteUrl)) {
+                return response()->json([
+                    'error' => 'Unauthorized Origin',
+                    'message' => 'This API key is strictly for ' . $site->site_url
+                ], 403);
+            }
+        }
+
+        // Attach site to request for the controller to use
+        $request->attributes->add(['site' => $site]);
+
+        return $next($request);
+    }
+}

--- a/server/app/Http/Resources/Admin/SiteResource.php
+++ b/server/app/Http/Resources/Admin/SiteResource.php
@@ -18,6 +18,7 @@ class SiteResource extends JsonResource
             'id' => $this->id,
             'name' => $this->site_name,
             'domain' => $this->site_url,
+            'apiKey' => $this->api_key,
             'status' => $this->site_status,
             'image' => $this->site_logo ?? '/images/HomesTV.png',
             'contact_name' => $this->contact_name,

--- a/server/app/Models/Site.php
+++ b/server/app/Models/Site.php
@@ -9,6 +9,15 @@ class Site extends Model
 {
     use HasFactory;
 
+    protected static function booted()
+    {
+        static::creating(function ($site) {
+            if (empty($site->api_key)) {
+                $site->api_key = \Illuminate\Support\Str::random(64);
+            }
+        });
+    }
+
     protected $table = 'sites';
 
     protected $fillable = [
@@ -20,6 +29,7 @@ class Site extends Model
         'site_status',
         'contact_name',
         'contact_email',
+        'api_key',
     ];
 
     protected $casts = [

--- a/server/bootstrap/app.php
+++ b/server/bootstrap/app.php
@@ -14,7 +14,8 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         // ✅ ADD THIS LINE to register your admin middleware alias
         $middleware->alias([
-            'is.admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
+            'is.admin'    => \App\Http\Middleware\EnsureUserIsAdmin::class,
+            'site.auth'   => \App\Http\Middleware\VerifySiteApiKey::class,
         ]);
 
         // You might have other middleware configurations here, leave them as they are.

--- a/server/database/migrations/2026_01_30_000000_add_api_key_to_sites_table.php
+++ b/server/database/migrations/2026_01_30_000000_add_api_key_to_sites_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. Add column as nullable first to allow existing rows
+        Schema::table('sites', function (Blueprint $table) {
+            $table->string('api_key', 64)->nullable()->after('site_url');
+        });
+
+        // 2. Generate API keys for existing sites
+        $sites = DB::table('sites')->get();
+        foreach ($sites as $site) {
+            DB::table('sites')
+                ->where('id', $site->id)
+                ->update(['api_key' => Str::random(64)]);
+        }
+
+        // 3. Make column NOT NULL and UNIQUE now that all rows have data
+        Schema::table('sites', function (Blueprint $table) {
+            $table->string('api_key', 64)->nullable(false)->unique()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->dropColumn('api_key');
+        });
+    }
+};

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -21,6 +21,8 @@ use Illuminate\Support\Facades\Route;
 Route::post('/subscribe', [SubscriptionController::class, 'store']);
 Route::get('/subscribe/{id}', [SubscriptionController::class, 'show']);
 Route::patch('/subscribe/{id}', [SubscriptionController::class, 'update']);
+// External Site Content API (Protected by API Key)
+Route::middleware('site.auth')->get('/external/articles', [\App\Http\Controllers\Api\SiteContentController::class, 'getArticles']);
 
 // ═══════════════════════════════════════════════════════════════
 // SYSTEM ROUTES (Redis Test, Health Check)
@@ -76,6 +78,7 @@ Route::middleware(['auth:sanctum', 'is.admin'])
 
         Route::get('sites/names', [SiteController::class, 'names']);
         Route::patch('sites/{id}/toggle-status', [SiteController::class, 'toggleStatus']);
+        Route::patch('sites/{id}/refresh-key', [SiteController::class, 'refreshKey']);
         Route::apiResource('sites', SiteController::class);
         Route::apiResource('articles', AdminArticleController::class)->except(['destroy']);
 


### PR DESCRIPTION
# Description
This PR implements a robust API Key authentication system for partner sites, allowing external websites to securely fetch and syndicate news articles. It includes automated key generation, admin management tools, and domain-locked security.

## Key Features
- **Site API Keys**: Added `api_key` field to the `sites` table with automatic generation for existing and new sites.
- **Secure Middleware**: Created [VerifySiteApiKey](cci:2://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/app/Http/Middleware/VerifySiteApiKey.php:9:0-51:1) middleware that validates keys and enforces **Origin (CORS) locking** in production to prevent unauthorized key usage.
- **Syndication Endpoint**: Added `GET /api/external/articles` for third-party sites to fetch articles specifically published for their platform.
- **Admin Management**: 
    - Display API keys in the Site Management dashboard.
    - Implemented a **"Show/Hide"** toggle and **"Copy to Clipboard"** for developer ease.
    - Added **API Key Rotation** (Regenerate) functionality to instantly invalidate old keys and issue new ones.

## Technical Changes
### Backend (Laravel)
- Created migration: `add_api_key_to_sites_table`.
- Added [SiteContentController](cci:2://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/app/Http/Controllers/Api/SiteContentController.php:7:0-29:1) to handle filtered external requests.
- Integrated [VerifySiteApiKey](cci:2://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/app/Http/Middleware/VerifySiteApiKey.php:9:0-51:1) middleware into [bootstrap/app.php](cci:7://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/bootstrap/app.php:0:0-0:0).
- Updated [Site](cci:2://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/app/Models/Site.php:7:0-68:1) model with a [booted](cci:1://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/server/app/Models/Site.php:11:4-18:5) method for auto-key generation on creation.

### Frontend (Next.js)
- Updated [SiteListItem](cci:1://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/client/components/features/admin/sites/SiteListItem.tsx:15:0-170:1) component with API key management UI using Lucide icons.
- Enhanced [sites.ts](cci:7://file:///c:/Users/Froillan%20Kim%20Edem/Documents/HomesPhNews/client/lib/api/admin/sites.ts:0:0-0:0) API client to support the new `refresh-key` endpoint.
- Updated TypeScript interfaces to include `apiKey` and related fields.

## How to Test
1. Run migrations: `php artisan migrate`.
2. Navigate to **Admin > Sites**.
3. Verify that each site now has an API Key displayed.
4. Test the "Regenerate" button to ensure the key rotates successfully.
5. Use `curl` to test the external endpoint:
   ```bash
   curl -H "X-Site-Api-Key: <YOUR_KEY>" -H "Accept: application/json" http://localhost:8000/api/external/articles