### PR TITLE
refactor(client): cleanup navigation container spacing and layout

### DIFF
--- a/client/components/layout/nav/LandingCategoryNav.tsx
+++ b/client/components/layout/nav/LandingCategoryNav.tsx
@@ -12,12 +12,10 @@ export type LandingCategoryNavProps = {
 
 export default function LandingCategoryNav({ categories }: LandingCategoryNavProps) {
   return (
-    <div className="bg-white w-full border-b border-[#e5e7eb]">
-      <div className="max-w-[1440px] mx-auto px-4 md:px-[110px] py-[16px]">
-        <Suspense fallback={<NavContentFallback categories={categories} />}>
-          <NavContent categories={categories} />
-        </Suspense>
-      </div>
+    <div className="bg-white w-full">
+      <Suspense fallback={<NavContentFallback categories={categories} />}>
+        <NavContent categories={categories} />
+      </Suspense>
     </div>
   );
 }

--- a/client/components/layout/nav/LandingCountryNav.tsx
+++ b/client/components/layout/nav/LandingCountryNav.tsx
@@ -12,12 +12,10 @@ export type LandingCountryNavProps = {
 
 export default function LandingCountryNav({ countries }: LandingCountryNavProps) {
   return (
-    <div className="bg-white w-full border-y border-[#e5e7eb]">
-      <div className="max-w-[1440px] mx-auto px-4 md:px-[110px] py-[16px]">
-        <Suspense fallback={<NavContentFallback countries={countries} />}>
-          <NavContent countries={countries} />
-        </Suspense>
-      </div>
+    <div className="bg-white w-full">
+      <Suspense fallback={<NavContentFallback countries={countries} />}>
+        <NavContent countries={countries} />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
refactor(client): cleanup navigation container spacing and layout

### Summary
This PR refines the layout of the [LandingCategoryNav](cci:1://file:///c:/Users/postr/Desktop/HomesPhNews/client/components/layout/nav/LandingCategoryNav.tsx:12:0-20:1) and [LandingCountryNav](cci:1://file:///c:/Users/postr/Desktop/HomesPhNews/client/components/layout/nav/LandingCountryNav.tsx:12:0-20:1) components. It simplifies the container structure by removing redundant internal padding and borders, ensuring a cleaner visual accumulation with the main header.

### Implementation
**Frontend:**
- **Container Cleanup**: Removed unnecessary `border-y` and padding from [LandingCountryNav.tsx](cci:7://file:///c:/Users/postr/Desktop/HomesPhNews/client/components/layout/nav/LandingCountryNav.tsx:0:0-0:0) and [LandingCategoryNav.tsx](cci:7://file:///c:/Users/postr/Desktop/HomesPhNews/client/components/layout/nav/LandingCategoryNav.tsx:0:0-0:0) to prevent double-borders and excessive whitespace when stacked.
- **Layout Consistency**: Simplified the wrapper divs to rely on the global layout constraints rather than component-specific overrides.

### Testing
**Manual:**
1. Navigate to the landing page.
2. Inspect the space between the main header, country nav, and category nav.
3. Verify that there are no double borders or uneven gaps between these navigation layers.