### PR TITLE
Server/refactor/edit subscription fixed

### DIFF
--- a/client/app/(landing)/subscribe/edit/EditSubscriptionClient.tsx
+++ b/client/app/(landing)/subscribe/edit/EditSubscriptionClient.tsx
@@ -35,9 +35,13 @@ function EditSubscriptionClient() {
     const fetchSubscription = async () => {
       try {
         const response = await getSubscriptionById(id);
-        const data = response.data;
+        // The API returns { status: 'success', data: { ... } }
+        // Type assertion needed because the interface definition currently doesn't match the wrapper
+        const apiResponse = response.data as any;
+        const data = apiResponse.data || apiResponse;
+
         setFormData({
-          email: data.email,
+          email: data.email || "",
           categories: Array.isArray(data.category) ? data.category : JSON.parse(data.category as string || "[]"),
           countries: Array.isArray(data.country) ? data.country : JSON.parse(data.country as string || "[]"),
         });

--- a/client/lib/api-v2/public/axios-instance.ts
+++ b/client/lib/api-v2/public/axios-instance.ts
@@ -1,4 +1,4 @@
-"use server";
+
 
 /**
  * This instance is intended to host the axios instance for public API calls.

--- a/client/lib/api-v2/public/services/subscription/index.ts
+++ b/client/lib/api-v2/public/services/subscription/index.ts
@@ -1,4 +1,3 @@
-"use server";
 
 import AXIOS_INSTANCE_PUBLIC from "../../axios-instance";
 import type { AxiosResponse } from "axios";

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -82,6 +82,7 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2716,6 +2717,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.42.2.tgz",
       "integrity": "sha512-KFqT8wb/d0bHbzvJEuD/vEU8lUSC5cZDurOMtAR3G+mUABqVWvVswQ/norjFXedjQe+nfQQ9CWrOabWcRP3TKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.41.1",
         "use-sync-external-store": "^1.6.0"
@@ -2831,6 +2833,7 @@
       "version": "20.19.30",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2839,6 +2842,7 @@
       "version": "19.2.9",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2847,6 +2851,7 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2894,6 +2899,7 @@
       "version": "8.53.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3367,6 +3373,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3717,6 +3724,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4384,6 +4392,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4553,6 +4562,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6511,6 +6521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6581,6 +6592,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6627,6 +6639,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6649,6 +6662,7 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6760,7 +6774,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7393,6 +7408,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7541,6 +7557,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7851,6 +7868,7 @@
       "version": "4.3.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/app/Http/Controllers/Api/SubscriptionController.php
+++ b/server/app/Http/Controllers/Api/SubscriptionController.php
@@ -17,9 +17,13 @@ class SubscriptionController extends Controller
      */
     public function show($id): JsonResponse
     {
-        $subscription = SubscriptionDetail::find($id);
+        // Try finding by the defined primary key column 'sub_Id'
+        $subscription = SubscriptionDetail::where('sub_Id', $id)->first();
 
         if (!$subscription) {
+            // Log the failure for debugging
+            \Log::warning("Subscription not found for ID: " . $id);
+
             return response()->json([
                 'status' => 'error',
                 'message' => 'Subscription not found.'
@@ -37,7 +41,7 @@ class SubscriptionController extends Controller
      */
     public function update(Request $request, $id): JsonResponse
     {
-        $subscription = SubscriptionDetail::find($id);
+        $subscription = SubscriptionDetail::where('sub_Id', $id)->first();
 
         if (!$subscription) {
             return response()->json([
@@ -164,7 +168,7 @@ class SubscriptionController extends Controller
                         'articles' => [], // Don't need articles for this one
                         'clientUrl' => env('APP_URL_CLIENT', 'http://localhost:3000'),
                         'actionUrl' => $editUrl,
-                        'actionText' => 'Manage Subscription',
+                        'actionText' => 'Edit your Preferences',
                         'subId' => $existing->sub_Id
                     ], function ($message) use ($request) {
                         $message->to($request->email)


### PR DESCRIPTION
Summary
This PR request fixes the edit subscription side to send a data to the client side normally without Maximum call stack size exceeded.

Implementation
removed the "use server" to avoid weird errors in the client side Maximum call stack size exceeded.
adds a route to send the data to the client subscribe/{id}