### PR TITLE
Server/feat/delete restore filter

### DIFF
--- a/client/app/admin/articles/page.tsx
+++ b/client/app/admin/articles/page.tsx
@@ -56,6 +56,7 @@ export default function ArticlesPage() {
         all: 0,
         published: 0,
         pending: 0,
+        deleted: 0,
     });
 
     // Effect: Fetch articles when filters change
@@ -91,6 +92,7 @@ export default function ArticlesPage() {
                         all: Number(status_counts.all),
                         published: Number(status_counts.published),
                         pending: Number(status_counts.pending),
+                        deleted: Number(status_counts.deleted || 0),
                     });
                 }
 

--- a/client/components/features/admin/articles/ArticlesTabs.tsx
+++ b/client/components/features/admin/articles/ArticlesTabs.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import { cn } from "@/lib/utils";
 
-export type ArticleTab = 'all' | 'published' | 'pending';
+export type ArticleTab = 'all' | 'published' | 'pending' | 'deleted';
 
 interface ArticlesTabsProps {
     activeTab: ArticleTab;
@@ -19,6 +19,7 @@ export default function ArticlesTabs({ activeTab, setActiveTab, counts }: Articl
         { id: 'all' as ArticleTab, label: 'All Articles' },
         { id: 'published' as ArticleTab, label: 'Published' },
         { id: 'pending' as ArticleTab, label: 'Pending Review' },
+        { id: 'deleted' as ArticleTab, label: 'Deleted' },
     ];
 
     return (

--- a/client/components/features/admin/shared/StatusBadge.tsx
+++ b/client/components/features/admin/shared/StatusBadge.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 
-export type StatusType = 'published' | 'pending' | 'rejected' | 'active' | 'inactive' | 'suspended';
+export type StatusType = 'published' | 'pending' | 'pending review' | 'rejected' | 'active' | 'inactive' | 'suspended' | 'deleted';
 
 interface StatusBadgeProps {
     status: StatusType;
@@ -30,11 +30,23 @@ export default function StatusBadge({ status, className }: StatusBadgeProps) {
             textColor: '#9a3412', // Deep Orange
             borderColor: '#fef08a',
         },
+        'pending review': {
+            label: 'Pending Review',
+            bgColor: '#fef9c3',
+            textColor: '#9a3412',
+            borderColor: '#fef08a',
+        },
         rejected: {
             label: 'Rejected',
             bgColor: '#fee2e2',
             textColor: '#991b1b',
             borderColor: '#fecaca',
+        },
+        deleted: {
+            label: 'Deleted',
+            bgColor: '#f3f4f6',
+            textColor: '#6b7280',
+            borderColor: '#e5e7eb',
         },
         inactive: {
             label: 'Inactive',

--- a/client/lib/api-v2/admin/service/article/getAdminArticles.ts
+++ b/client/lib/api-v2/admin/service/article/getAdminArticles.ts
@@ -14,7 +14,7 @@ export type AdminArticleListParams = {
   topics?: string;
   limit?: number;
   offset?: number;
-  status?: "published" | "pending" | "rejected" | "pending review" | "all";
+  status?: "published" | "pending" | "rejected" | "pending review" | "all" | "deleted";
   sort_by?: "created_at" | "views_count" | "title" | "timestamp";
   sort_direction?: "asc" | "desc";
   per_page?: number;
@@ -29,6 +29,7 @@ export interface AdminArticleStatusCounts {
   pending: number | string;
   rejected: number | string;
   pending_review: number | string;
+  deleted: number | string;
 }
 
 export interface AdminArticleAvailableFilters {

--- a/client/lib/api-v2/admin/service/article/restoreArticle.ts
+++ b/client/lib/api-v2/admin/service/article/restoreArticle.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import AXIOS_INSTANCE_ADMIN from "../../axios-instance";
+import type { AxiosResponse } from "axios";
+
+/**
+ * Restore a soft-deleted article.
+ * POST /admin/articles/{id}/restore
+ */
+export async function restoreArticle(id: string): Promise<AxiosResponse<any>> {
+    return AXIOS_INSTANCE_ADMIN.post(`/admin/articles/${id}/restore`);
+}

--- a/client/lib/api-v2/types/ArticleResource.ts
+++ b/client/lib/api-v2/types/ArticleResource.ts
@@ -15,4 +15,5 @@ export interface ArticleResource {
   created_at: string;
   published_sites: string | string[];
   image_url?: string;
+  is_deleted?: boolean;
 }

--- a/server/app/Http/Controllers/Api/User/ArticleController.php
+++ b/server/app/Http/Controllers/Api/User/ArticleController.php
@@ -43,7 +43,7 @@ class ArticleController extends Controller
         $query = Article::query();
 
         // Always filter by published status for public feed
-        $query->where('status', 'published');
+        $query->where('status', 'published')->where('is_deleted', false);
 
         if ($search) {
             $query->where(function ($q) use ($search) {
@@ -100,7 +100,7 @@ class ArticleController extends Controller
         $country = $validated['country'] ?? null;
         $category = $validated['category'] ?? null;
 
-        $baseQuery = Article::where('status', 'published');
+        $baseQuery = Article::where('status', 'published')->where('is_deleted', false);
 
         if ($country) {
             $baseQuery->where('country', $country);
@@ -149,7 +149,9 @@ class ArticleController extends Controller
     public function show(string $id): JsonResponse|ArticleResource
     {
         // Eager load relationships to prevent N+1
-        $article = Article::with(['publishedSites:id,site_name', 'images:article_id,image_path'])->find($id);
+        $article = Article::with(['publishedSites:id,site_name', 'images:article_id,image_path'])
+            ->where('is_deleted', false)
+            ->find($id);
 
         if (! $article) {
             // Fallback to Redis if not found in DB

--- a/server/app/Http/Requests/Articles/ArticleQueryRequest.php
+++ b/server/app/Http/Requests/Articles/ArticleQueryRequest.php
@@ -31,7 +31,7 @@ class ArticleQueryRequest extends FormRequest
             'topics' => 'nullable|string',
             'limit' => 'nullable|integer|min:1|max:100',
             'offset' => 'nullable|integer|min:0',
-            'status' => 'nullable|string|in:published,pending,rejected,pending review,all',
+            'status' => 'nullable|string|in:published,pending,rejected,pending review,all,deleted',
             'sort_by' => 'nullable|string|in:created_at,views_count,title,timestamp',
             'sort_direction' => 'nullable|string|in:asc,desc',
             'per_page' => 'nullable|integer|min:1|max:100',

--- a/server/app/Http/Requests/Articles/StoreArticleRequest.php
+++ b/server/app/Http/Requests/Articles/StoreArticleRequest.php
@@ -30,7 +30,7 @@ class StoreArticleRequest extends FormRequest
             'image' => 'nullable|string|max:2000',
             'published_sites' => 'nullable|array',
             'published_sites.*' => 'string',
-            'status' => 'nullable|string|in:published,pending review',
+            'status' => 'nullable|string|in:published,pending review,deleted',
             'topics' => 'nullable|array',
             // Extra fields from editor (not stored in articles table but accepted)
             'gallery_images' => 'nullable|array',

--- a/server/app/Http/Requests/Articles/UpdateArticleRequest.php
+++ b/server/app/Http/Requests/Articles/UpdateArticleRequest.php
@@ -31,7 +31,7 @@ class UpdateArticleRequest extends FormRequest
             'image_url' => 'nullable|string|max:500', // Support both for flexiblity
             'published_sites' => 'nullable|array',
             'published_sites.*' => 'string',
-            'status' => 'nullable|string|in:published,pending review,rejected',
+            'status' => 'nullable|string|in:published,pending review,rejected,deleted',
             'custom_titles' => 'nullable|array',
             'topics' => 'nullable|array',
             'keywords' => 'nullable|string|max:255',

--- a/server/app/Http/Resources/Articles/ArticleResource.php
+++ b/server/app/Http/Resources/Articles/ArticleResource.php
@@ -92,7 +92,7 @@ class ArticleResource extends JsonResource
             'content' => (string) ($data['content'] ?? ''),
             'category' => (string) ($data['category'] ?? ''),
             'country' => (string) ($data['country'] ?? ($data['location'] ?? 'Global')),
-            'status' => (string) ($data['status'] ?? 'pending'),
+            'status' => (bool) ($data['is_deleted'] ?? false) ? 'deleted' : (string) ($data['status'] ?? 'pending'),
             'created_at' => $createdAt,
             'views_count' => (int) ($data['views_count'] ?? 0),
             
@@ -116,6 +116,7 @@ class ArticleResource extends JsonResource
             'keywords' => (string) ($data['keywords'] ?? ''),
             'source' => (string) ($data['source'] ?? ''),
             'original_url' => (string) ($data['original_url'] ?? ''),
+            'is_deleted' => (bool) ($data['is_deleted'] ?? false),
         ];
     }
 }

--- a/server/app/Models/Article.php
+++ b/server/app/Models/Article.php
@@ -29,6 +29,7 @@ class Article extends Model
         'keywords',
         'topics',          // JSON array of topics
         'published_sites', // JSON array of site names
+        'is_deleted',
     ];
 
     /**
@@ -40,6 +41,7 @@ class Article extends Model
         'topics' => 'array',
         'published_sites' => 'array', // ["FilipinoHomes", "Rent.ph", ...]
         'views_count' => 'integer',
+        'is_deleted' => 'boolean',
     ];
 
     /**

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -88,6 +88,8 @@ Route::middleware(['auth:sanctum', 'is.admin'])
         Route::patch('articles/{id}/pending', [AdminArticleController::class, 'updatePending']);
         // Publish pending article (Redis → MySQL, then delete from Redis)
         Route::post('articles/{id}/publish', [AdminArticleController::class, 'publish']);
+        // Restore soft-deleted article
+        Route::post('articles/{id}/restore', [AdminArticleController::class, 'restore']);
 
         // Upload Routes
         Route::post('upload/image', [UploadController::class, 'uploadImage'])->name('upload.image');


### PR DESCRIPTION
feat(auth): add soft delete, restore soft delete, and filter function in the article page

### Summary
This PR introduces adds soft delete, restore soft delete, and filter function in the article page

### Implementation

Manual:

### Delete 
Go to Article page in the admin
Click a certain article
Press Delete
The article will go to the Delete column

### Restore 
Click deleted article
Click Restore
It will restore the article to its previous status

### Filter
On the search box
Type an existing article
It should appear
Filter  by country and category should work