### PR TITLE
fix(client): fix and reimplement dark mode

### DIFF
--- a/client/app/(landing)/layout.tsx
+++ b/client/app/(landing)/layout.tsx
@@ -12,7 +12,7 @@ export default function LandingLayout({
 }) {
   return (
     <div className="min-h-screen bg-[#f9fafb] dark:bg-[#030712] flex flex-col pt-[120px] transition-colors duration-300">
-      <Suspense fallback={<div className="h-[72px] bg-white border-b border-[#e5e7eb]" />}>
+      <Suspense fallback={<div className="h-[72px] bg-white dark:bg-[#1a1d2e] border-b border-[#e5e7eb] dark:border-[#2a2d3e]" />}>
         <LandingHeader />
       </Suspense>
       <LandingCountryNav countries={Countries} />

--- a/client/app/(landing)/restaurants/page.tsx
+++ b/client/app/(landing)/restaurants/page.tsx
@@ -258,8 +258,8 @@ export default async function RestaurantPage() {
                             <LatestPostsSection articles={latestPosts} />
                         </>
                     ) : (
-                        <div className="bg-white rounded-xl border border-gray-200 p-12 text-center text-gray-500">
-                            <p className="font-semibold text-lg text-gray-900 mb-1">
+                        <div className="bg-white dark:bg-[#1a1d2e] rounded-xl border border-gray-200 dark:border-[#2a2d3e] p-12 text-center text-gray-500 dark:text-gray-400">
+                            <p className="font-semibold text-lg text-gray-900 dark:text-white mb-1">
                                 No restaurant articles found
                             </p>
                         </div>

--- a/client/components/features/article/ArticleBreadcrumb.tsx
+++ b/client/components/features/article/ArticleBreadcrumb.tsx
@@ -25,14 +25,14 @@ export default function ArticleBreadcrumb({
   const finalCountryHref = countryHref || (countryId ? `/?country=${countryId}` : "/");
 
   return (
-    <p className="font-normal text-[16px] text-[#4b5563] tracking-[-0.5px] leading-[24px] mb-6">
-      <Link href={homeHref} className="hover:text-[#c10007] transition-colors">{homeLabel}</Link>
+    <p className="font-normal text-[16px] text-[#4b5563] dark:text-gray-400 tracking-[-0.5px] leading-[24px] mb-6">
+      <Link href={homeHref} className="hover:text-[#c10007] dark:hover:text-[#c10007] transition-colors">{homeLabel}</Link>
       {category && (
         <>
           {"  /  "}
           <Link
             href={finalCategoryHref}
-            className="hover:text-[#c10007] transition-colors shadow-none"
+            className="hover:text-[#c10007] dark:hover:text-[#c10007] transition-colors shadow-none"
           >
             {category}
           </Link>
@@ -43,7 +43,7 @@ export default function ArticleBreadcrumb({
           {"  /  "}
           <Link
             href={finalCountryHref}
-            className="hover:text-[#c10007] transition-colors"
+            className="hover:text-[#c10007] dark:hover:text-[#c10007] transition-colors"
           >
             {country}
           </Link>

--- a/client/components/features/article/ArticleFeaturedImage.tsx
+++ b/client/components/features/article/ArticleFeaturedImage.tsx
@@ -19,7 +19,7 @@ export default function ArticleFeaturedImage({ src, alt, caption }: ArticleFeatu
         />
       </div>
       {caption && (
-        <p className="text-sm text-gray-500 mt-2 text-center italic">{caption}</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 text-center italic">{caption}</p>
       )}
     </div>
   );

--- a/client/components/features/article/ArticleSkeletons.tsx
+++ b/client/components/features/article/ArticleSkeletons.tsx
@@ -9,7 +9,7 @@ export function ArticleHeaderSkeleton() {
     <div className="space-y-4 mb-8">
       <div className="flex gap-4 items-center mb-6">
         <Skeleton className="h-8 w-24" />
-        <div className="h-5 w-px bg-gray-200" />
+        <div className="h-5 w-px bg-gray-200 dark:bg-gray-700" />
         <Skeleton className="h-5 w-32" />
       </div>
       <Skeleton className="h-[42px] md:h-[48px] w-full" />
@@ -17,7 +17,7 @@ export function ArticleHeaderSkeleton() {
       <Skeleton className="h-6 w-full mt-4" />
       <Skeleton className="h-6 w-1/2" />
 
-      <div className="flex items-center justify-between border-y border-[#e5e7eb] py-[20px] mt-12">
+      <div className="flex items-center justify-between border-y border-[#e5e7eb] dark:border-[#2a2d3e] py-[20px] mt-12">
         <div className="flex gap-8 items-center">
           <Skeleton className="h-5 w-24" />
           <Skeleton className="h-5 w-32" />
@@ -57,7 +57,7 @@ export function SidebarSkeleton() {
   return (
     <div className="space-y-8">
       <Skeleton className="h-[112px] w-full rounded-xl" />
-      <div className="bg-white rounded-xl border p-6 space-y-4">
+      <div className="bg-white dark:bg-[#1a1d2e] rounded-xl border dark:border-[#2a2d3e] p-6 space-y-4">
         <Skeleton className="h-6 w-32" />
         {[1, 2, 3, 4].map((i) => (
           <div key={i} className="flex gap-3">

--- a/client/components/features/article/RelatedArticles.tsx
+++ b/client/components/features/article/RelatedArticles.tsx
@@ -23,7 +23,7 @@ export default function RelatedArticles({ articles }: RelatedArticlesProps) {
 
   return (
     <div className="flex flex-col gap-[24px] mt-[40px]">
-      <h2 className="font-bold text-[24px] text-[#111827] tracking-[-0.5px] leading-[32px]">
+      <h2 className="font-bold text-[24px] text-[#111827] dark:text-white tracking-[-0.5px] leading-[32px]">
         Related Articles
       </h2>
 
@@ -32,7 +32,7 @@ export default function RelatedArticles({ articles }: RelatedArticlesProps) {
           <Link
             key={article.id}
             href={`/article?id=${article.id}`}
-            className="bg-white border border-[#f3f4f6] rounded-[12px] overflow-hidden cursor-pointer hover:shadow-md transition-shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)]"
+            className="bg-white dark:bg-[#1a1d2e] border border-[#f3f4f6] dark:border-[#2a2d3e] rounded-[12px] overflow-hidden cursor-pointer hover:shadow-md transition-shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)]"
           >
             {/* Image on top */}
             <div className="w-full h-[160px] overflow-hidden">
@@ -48,24 +48,24 @@ export default function RelatedArticles({ articles }: RelatedArticlesProps) {
             {/* Content below */}
             <div className="p-[16px] flex flex-col gap-[10px]">
               <div className="flex gap-[8px] items-center">
-                <span className="bg-white border border-[#e5e7eb] px-[8px] py-[3px] rounded-[4px] font-semibold text-[11px] text-black tracking-[-0.5px]">
+                <span className="bg-white dark:bg-[#252836] border border-[#e5e7eb] dark:border-[#374151] px-[8px] py-[3px] rounded-[4px] font-semibold text-[11px] text-black dark:text-white tracking-[-0.5px]">
                   {article.category}
                 </span>
                 {article.location && (
                   <>
-                    <p className="font-normal text-[12px] text-black tracking-[-0.5px]">|</p>
-                    <p className="font-semibold text-[11px] text-black tracking-[-0.5px]">
+                    <p className="font-normal text-[12px] text-black dark:text-gray-400 tracking-[-0.5px]">|</p>
+                    <p className="font-semibold text-[11px] text-black dark:text-white tracking-[-0.5px]">
                       {article.location.toUpperCase()}
                     </p>
                   </>
                 )}
               </div>
 
-              <h3 className="font-bold text-[16px] text-[#111827] tracking-[-0.5px] leading-[1.3] line-clamp-2">
+              <h3 className="font-bold text-[16px] text-[#111827] dark:text-white tracking-[-0.5px] leading-[1.3] line-clamp-2">
                 {article.title}
               </h3>
 
-              <div className="flex items-center gap-[6px] text-[#6b7280]">
+              <div className="flex items-center gap-[6px] text-[#6b7280] dark:text-gray-400">
                 <Clock className="size-[12px]" />
                 <p className="font-normal text-[12px] tracking-[-0.5px]">
                   {article.timeAgo}

--- a/client/components/layout/nav/LandingCategoryNav.tsx
+++ b/client/components/layout/nav/LandingCategoryNav.tsx
@@ -12,7 +12,7 @@ export type LandingCategoryNavProps = {
 
 export default function LandingCategoryNav({ categories }: LandingCategoryNavProps) {
   return (
-    <div className="bg-white w-full">
+    <div className="bg-white dark:bg-[#1a1d2e] w-full">
       <Suspense fallback={<NavContentFallback categories={categories} />}>
         <NavContent categories={categories} />
       </Suspense>
@@ -55,7 +55,7 @@ function NavContent({ categories }: LandingCategoryNavProps) {
                 key={category.id}
                 onClick={() => handleChangeCategoryTab(category.id)}
                 className={`shrink-0 font-medium text-[14px] tracking-[-0.5px] whitespace-nowrap transition-colors ${isActive
-                  ? "bg-[#030213] text-white px-[10px] py-[5px] rounded-[6px]"
+                  ? "bg-[#030213] dark:bg-white text-white dark:text-[#030213] px-[10px] py-[5px] rounded-[6px]"
                   : "text-[#374151] dark:text-gray-300 hover:text-[#c10007] dark:hover:text-[#c10007] px-0 py-px"
                   }`}
               >
@@ -75,7 +75,7 @@ function NavContentFallback({ categories }: LandingCategoryNavProps) {
       {categories.map((category) => (
         <div
           key={category.id}
-          className="shrink-0 font-medium text-[14px] tracking-[-0.5px] whitespace-nowrap text-[#374151] px-0 py-px"
+          className="shrink-0 font-medium text-[14px] tracking-[-0.5px] whitespace-nowrap text-[#374151] dark:text-gray-400 px-0 py-px"
         >
           {category.label}
         </div>

--- a/client/components/shared/AdSpace.tsx
+++ b/client/components/shared/AdSpace.tsx
@@ -17,13 +17,13 @@ export default function AdSpace({
 }: AdSpaceProps) {
     return (
         <div className={cn(
-            "bg-white rounded-[12px] border border-dashed border-[#e5e7eb] shadow-sm p-[25px] text-center flex flex-col items-center justify-center",
+            "bg-white dark:bg-[#1a1d2e] rounded-[12px] border border-dashed border-[#e5e7eb] dark:border-[#2a2d3e] shadow-sm p-[25px] text-center flex flex-col items-center justify-center",
             className
         )}>
-            <p className="font-semibold text-[16px] text-[#111827] tracking-[-0.5px] mb-2">
+            <p className="font-semibold text-[16px] text-[#111827] dark:text-white tracking-[-0.5px] mb-2">
                 {label}
             </p>
-            <p className="font-normal text-[12px] text-[#6b7280] tracking-[-0.5px]">
+            <p className="font-normal text-[12px] text-[#6b7280] dark:text-gray-400 tracking-[-0.5px]">
                 {width} {height}
             </p>
         </div>


### PR DESCRIPTION
### Summary
This PR fixes hard-coded colors across multiple UI components and layouts to ensure proper dark mode functionality. Previously, several components used explicit color values without corresponding `dark:` variants, causing incorrect rendering in dark mode.

### Implementation

**Article Components:**
- `ArticleBreadcrumb.tsx` - Added `dark:text-gray-400` for text and `dark:hover:text-[#c10007]` for link hover states
- `ArticleFeaturedImage.tsx` - Added `dark:text-gray-400` to image caption
- `ArticleSkeletons.tsx` - Added `dark:border-[#2a2d3e]` for borders and `dark:bg-[#1a1d2e]` for sidebar background
- `RelatedArticles.tsx` - Added comprehensive dark mode variants for card backgrounds (`dark:bg-[#1a1d2e]`), borders, category badges, and text colors

**Layout Components:**
- `LandingCategoryNav.tsx` - Added dark mode for wrapper background and active button styling with inverted colors in dark mode

**Shared Components:**
- `AdSpace.tsx` - Added dark mode variants for background, dashed border, and text colors

**App Pages:**
- `layout.tsx` - Fixed Suspense fallback skeleton to include dark mode background and border
- `restaurants/page.tsx` - Fixed empty state container with dark mode background, border, and text colors