### PR TITLE
Server/refactor/added route for scheduler

### DIFF
--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -30,6 +30,20 @@ Route::middleware('site.auth')->get('/external/articles', [\App\Http\Controllers
 Route::get('/redis-test', [SystemController::class, 'redisTest']);
 Route::get('/db-test', [SystemController::class, 'dbTest']);
 
+// ═══════════════════════════════════════════════════════════════
+// SCHEDULER ROUTE (For Cloud Run / Cron Jobs)
+// ═══════════════════════════════════════════════════════════════
+Route::get('/scheduler/run', function () {
+    // ⚠️ Security Note: In production, you should protect this route!
+    // Example: if (request('key') !== env('CRON_KEY')) abort(403);
+    
+    \Illuminate\Support\Facades\Artisan::call('schedule:run');
+    return response()->json([
+        'message' => 'Schedule executed',
+        'output' => \Illuminate\Support\Facades\Artisan::output()
+    ]);
+});
+
 // Public login route
 Route::post('/login', [AuthController::class, 'login'])->middleware('throttle:login');
 Route::get('/login', [AuthController::class, 'me'])->middleware('auth:sanctum')->name('login');


### PR DESCRIPTION
### Summary
This PR requests the scheduler routes to send an email every 8:00 AM using cron job. The scheduler will execute every minute to execute the newsletter:send in the exact time every morning. 
### Implementation

- new route implemented in the api.php: /scheduler/run
- cron job will manage the execution every minute based on the provided scheduler \Illuminate\Support\Facades\Artisan::call('schedule:run');


# ⏰ Global Scheduler Endpoint

This endpoint serves as a remote trigger for the Laravel task scheduler. It allows external services (like Google Cloud Scheduler, EasyCron, or a separate worker) to execute the application's scheduled tasks over HTTP.

### **Endpoint**
`GET /api/scheduler/run`

### **Description**
Triggers the `php artisan schedule:run` command on the server. This is essential for environments like **Google Cloud Run** or **Docker**, where running a persistent background cron daemon is not possible.

### **Usage**
This endpoint should be called **every minute** by an external scheduler.

**Request:**
```http
GET [https://news.homes.ph/api/scheduler/run](https://news.homes.ph/api/scheduler/run) HTTP/1.1
Content-Type: application/json

{
    "message": "Schedule executed",
    "output": "Running scheduled command: App\\Console\\Commands\\NewsletterSend..."
}