### PR TITLE
refactor(admin): update analytics dashboard with total views metric

### DIFF
--- a/client/app/(landing)/article/page.tsx
+++ b/client/app/(landing)/article/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 
 import ArticleViewCounter from "@/components/features/article/ArticleViewCounter";
-import AdSpace from "@/lib/ads/components/AdSpace";
+import { AdSpace } from "@/lib/ads/components/AdSpace";
 import { notFound } from "next/navigation";
 import {
   ArticleHeaderSkeleton,

--- a/client/app/(landing)/restaurants/page.tsx
+++ b/client/app/(landing)/restaurants/page.tsx
@@ -4,7 +4,7 @@ import MostReadTodayCard from "@/components/features/dashboard/MostReadTodayCard
 import TrendingTopicsCard from "@/components/features/dashboard/TrendingTopicsCard";
 import LatestPostsSection from "@/components/features/dashboard/LatestPostsSection";
 import LandingHeroCarousel from "@/components/features/dashboard/LandingHeroCarousel";
-import AdSpace from "@/lib/ads/components/AdSpace";
+import { AdSpace } from "@/lib/ads/components/AdSpace";
 import Link from 'next/link';
 import type { ArticleResource } from "@/lib/api-v2/types/ArticleResource";
 

--- a/client/app/admin/analytics/page.tsx
+++ b/client/app/admin/analytics/page.tsx
@@ -85,6 +85,14 @@ export default function AnalyticsPage() {
                         iconColor: "text-purple-500"
                     },
                     {
+                        title: "Total Views",
+                        value: overview.total_page_news,
+                        trend: overview.total_page_news_trend,
+                        iconName: "Eye",
+                        iconBgColor: "bg-indigo-50",
+                        iconColor: "text-indigo-500"
+                    },
+                    {
                         title: "Total Clicks",
                         value: overview.total_clicks,
                         trend: overview.total_clicks_trend,
@@ -105,8 +113,8 @@ export default function AnalyticsPage() {
                         value: overview.avg_read_duration,
                         trend: "+0%",
                         iconName: "Clock",
-                        iconBgColor: "bg-indigo-50",
-                        iconColor: "text-indigo-500"
+                        iconBgColor: "bg-teal-50", // Changed color to distinguish
+                        iconColor: "text-teal-500"
                     }
                 ]);
 
@@ -324,9 +332,9 @@ export default function AnalyticsPage() {
 
 
             {/* Analytics Stats Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6 mb-8">
                 {isLoading ? (
-                    Array(5).fill(0).map((_, i) => <Skeleton key={i} className="h-[140px] rounded-[12px] bg-white shadow-sm" />)
+                    Array(6).fill(0).map((_, i) => <Skeleton key={i} className="h-[140px] rounded-[12px] bg-white shadow-sm" />)
                 ) : (
                     stats.map((stat, index) => (
                         <StatCard

--- a/client/components/features/article/RelatedArticlesSidebar.tsx
+++ b/client/components/features/article/RelatedArticlesSidebar.tsx
@@ -1,7 +1,7 @@
 import { getArticleById, getArticlesList } from "@/lib/api-v2";
 import { mockSpecialtyContent } from "@/lib/api-v2/mock/mockArticles";
 import MostReadTodayCard from "@/components/features/dashboard/MostReadTodayCard";
-import AdSpace from "@/lib/ads/components/AdSpace";
+import { AdSpace } from "@/lib/ads/components/AdSpace";
 
 interface RelatedArticlesSidebarProps {
   id: string;

--- a/client/components/features/dashboard/DashboardFeed.tsx
+++ b/client/components/features/dashboard/DashboardFeed.tsx
@@ -6,7 +6,7 @@ import TrendingTopicsCard from "@/components/features/dashboard/TrendingTopicsCa
 import MostReadTodayCard from "@/components/features/dashboard/MostReadTodayCard";
 import CategoriesSidebarCard from "./CategoriesSidebarCard";
 import LatestPostsSection from "./LatestPostsSection";
-import AdSpace from "@/lib/ads/components/AdSpace";
+import { AdSpace } from "@/lib/ads/components/AdSpace";
 import { use } from "react";
 import { ArticleResource, FeedResponse } from "@/lib/api-v2";
 import { mockSpecialtyContent } from "@/lib/api-v2/mock/mockArticles";

--- a/client/lib/ads/components/AdSpace.tsx
+++ b/client/lib/ads/components/AdSpace.tsx
@@ -92,7 +92,7 @@ function AdContent({ className, rotateInterval }: AdSpaceProps) {
   );
 }
 
-export default function AdSpace({ className, rotateInterval }: AdSpaceProps) {
+export function AdSpace({ className, rotateInterval }: AdSpaceProps) {
   return (
     <Suspense
       fallback={

--- a/client/lib/ads/index.ts
+++ b/client/lib/ads/index.ts
@@ -1,1 +1,1 @@
-export { default as AdSpace } from "./components/AdSpace";
+export { AdSpace } from "./components/AdSpace";


### PR DESCRIPTION
refactor(admin): update analytics dashboard with total views metric

### Summary
This PR refactors the Admin Analytics dashboard to include a high-level **Total Views** metric. It improves the layout of the stats grid to accommodate the new data point and applies minor visual updates for better readability.

### Implementation
**Frontend (Analytics):**
- **New Metric**: Added "Total Views" to the top-level stats overview, aggregating `total_page_news` data.
- **Layout**: Updated the stats grid to a 6-column layout (`xl:grid-cols-6`) to fit the additional card.
- **Visuals**: Adjusted icon colors (Teal/Indigo) for "Total Views" and "Avg Read Duration" to ensure visual distinction.

### Testing
**Manual:**
1. Navigate to **Admin > Analytics**.
2. Verify that the "Total Views" card appears in the stats row.
3. Check that the value matches the expected aggregated count from the timeframe.
4. Verify the grid layout adjusts correctly on different screen sizes.