### PR TITLE
refactor(article): implement slug-based redirects and dual ID/Slug su…

### DIFF
--- a/client/app/(landing)/article/page.tsx
+++ b/client/app/(landing)/article/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 
 import ArticleViewCounter from "@/components/features/article/ArticleViewCounter";
 import AdSpace from "@/components/features/admin/ads/AdSpace";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
   ArticleHeaderSkeleton,
   ArticleContentSkeleton,
@@ -21,8 +21,8 @@ interface Props {
 }
 
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
-  const { id } = await searchParams;
-  const articleId = Array.isArray(id) ? id[0] : id;
+  const { id, slug } = await searchParams;
+  const articleId = (Array.isArray(slug) ? slug[0] : slug) || (Array.isArray(id) ? id[0] : id);
 
   if (!articleId) {
     return {
@@ -70,11 +70,28 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 }
 
 export default async function Article({ searchParams }: Props) {
-  const { id } = await searchParams;
-  const articleId = Array.isArray(id) ? id[0] : id;
+  const { id, slug } = await searchParams;
+  const articleId = (Array.isArray(slug) ? slug[0] : slug) || (Array.isArray(id) ? id[0] : id);
 
   if (!articleId) {
     notFound();
+  }
+
+  // If accessed by ID, but has a slug, redirect to the slug URL
+  let redirectTo = null;
+  if (id && !slug) {
+    try {
+      const article = await getArticleById(Array.isArray(id) ? id[0] : id);
+      if (article && article.slug) {
+        redirectTo = `/article?slug=${article.slug}`;
+      }
+    } catch (error) {
+      console.error("Error checking for slug redirect:", error);
+    }
+  }
+
+  if (redirectTo) {
+    redirect(redirectTo);
   }
 
   return (

--- a/client/components/features/admin/articles/ArticleEditorModal.tsx
+++ b/client/components/features/admin/articles/ArticleEditorModal.tsx
@@ -248,7 +248,7 @@ export default function ArticleEditorModal({ mode, isOpen, onClose, initialData 
 
             const payload = {
                 title: articleData.title,
-                slug: articleData.slug,
+                slug: articleData.slug || articleData.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
                 summary: articleData.summary,
                 content: articleData.content,
                 category: articleData.category,

--- a/client/components/features/article/RelatedArticlesSidebar.tsx
+++ b/client/components/features/article/RelatedArticlesSidebar.tsx
@@ -34,6 +34,7 @@ export default async function RelatedArticlesSidebar({ id }: RelatedArticlesSide
       .slice(0, 4)
       .map((a) => ({
         id: a.id,
+        slug: a.slug,
         title: a.title,
         views: a.views_count,
         imageUrl: a.image || "/healthcare.jpg",

--- a/client/components/features/dashboard/ArticleCard.tsx
+++ b/client/components/features/dashboard/ArticleCard.tsx
@@ -9,6 +9,7 @@ import ShareButtons from "@/components/shared/ShareButtons";
 
 interface ArticleCardProps {
   id: string
+  slug?: string
   category: string
   location?: string
   title: string
@@ -22,6 +23,7 @@ interface ArticleCardProps {
 
 export default function ArticleCard({
   id,
+  slug,
   category,
   location,
   title,
@@ -34,7 +36,7 @@ export default function ArticleCard({
 }: ArticleCardProps) {
   return (
     <Link
-      href={`/article?id=${id}`}
+      href={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
       className={cn(
         'group flex gap-6 rounded-[12px] border border-[#f3f4f6] bg-white p-6 shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] transition-all hover:bg-transparent',
         className
@@ -69,7 +71,7 @@ export default function ArticleCard({
         {/* Share Icons - Bottom Right */}
         <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
           <ShareButtons
-            url={`/article?id=${id}`}
+            url={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
             title={title}
             description={description}
             size="xs"

--- a/client/components/features/dashboard/DashboardFeed.tsx
+++ b/client/components/features/dashboard/DashboardFeed.tsx
@@ -255,6 +255,7 @@ export default function DashboardFeed({ country, category, feed }: DashboardFeed
                     <MostReadTodayCard
                         items={most_read.slice(0, 5).map((article) => ({
                             id: article.id || '',
+                            slug: article.slug,
                             title: article.title,
                             imageUrl: article.image_url || article.image || 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7', // Fallback image
                             views: article.views_count || 0,

--- a/client/components/features/dashboard/LandingHeroGrid.tsx
+++ b/client/components/features/dashboard/LandingHeroGrid.tsx
@@ -22,7 +22,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
         return (
             <div className="mb-8 md:h-[405px]">
                 <Link
-                    href={`/article?id=${main.id}`}
+                    href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                     className="relative group cursor-pointer block w-full h-full overflow-hidden"
                 >
                     <Image
@@ -56,7 +56,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                 <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                             </div>
                             <ShareButtons
-                                url={`/article?id=${main.id}`}
+                                url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                                 title={main.title}
                                 description={main.summary || main.content}
                                 size="sm"
@@ -76,7 +76,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                 {articles.map((article) => (
                     <Link
                         key={article.id}
-                        href={`/article?id=${article.id}`}
+                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                         className="relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
                     >
                         <Image
@@ -106,7 +106,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                     <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                 </div>
                                 <ShareButtons
-                                    url={`/article?id=${article.id}`}
+                                    url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                     title={article.title}
                                     description={article.summary || article.content}
                                     size="sm"
@@ -128,7 +128,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
             <div className="flex overflow-x-auto snap-x snap-mandatory md:grid md:grid-cols-4 gap-1 mb-8 h-[400px] md:h-[405px] scrollbar-hide">
                 {/* Main Article (Left Half) */}
                 <Link
-                    href={`/article?id=${main.id}`}
+                    href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                     className="md:col-span-2 relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
                 >
                     <Image
@@ -159,7 +159,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                 <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                             </div>
                             <ShareButtons
-                                url={`/article?id=${main.id}`}
+                                url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                                 title={main.title}
                                 description={main.summary || main.content}
                                 size="sm"
@@ -174,7 +174,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                     {[side1, side2].map((article) => (
                         <Link
                             key={article.id}
-                            href={`/article?id=${article.id}`}
+                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                             className="relative group cursor-pointer overflow-hidden h-full block"
                         >
                             <Image
@@ -204,7 +204,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                         <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                     </div>
                                     <ShareButtons
-                                        url={`/article?id=${article.id}`}
+                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                         title={article.title}
                                         size="xs"
                                         className="transition-opacity"
@@ -227,7 +227,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
         <div className="flex overflow-x-auto snap-x snap-mandatory md:grid md:grid-cols-4 gap-1 mb-8 h-[400px] md:h-[405px] scrollbar-hide">
             {/* Large Main Article */}
             <Link
-                href={`/article?id=${main.id}`}
+                href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                 className="md:col-span-2 relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
             >
                 <Image
@@ -261,7 +261,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                             <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                         </div>
                         <ShareButtons
-                            url={`/article?id=${main.id}`}
+                            url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                             title={main.title}
                             description={main.summary || main.content}
                             size="sm"
@@ -276,7 +276,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                 {/* Top Medium Article */}
                 {topSmall && (
                     <Link
-                        href={`/article?id=${topSmall.id}`}
+                        href={topSmall.slug ? `/article?slug=${topSmall.slug}` : `/article?id=${topSmall.id}`}
                         className="relative group cursor-pointer overflow-hidden h-[200px] block"
                     >
                         <Image
@@ -306,7 +306,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                     <span>{topSmall.created_at ? new Date(topSmall.created_at).toLocaleDateString() : 'Recently'}</span>
                                 </div>
                                 <ShareButtons
-                                    url={`/article?id=${topSmall.id}`}
+                                    url={topSmall.slug ? `/article?slug=${topSmall.slug}` : `/article?id=${topSmall.id}`}
                                     title={topSmall.title}
                                     description={topSmall.summary || topSmall.content}
                                     size="xs"
@@ -322,7 +322,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                     {[bottomSmall1, bottomSmall2].map((article, idx) => article ? (
                         <Link
                             key={article.id || idx}
-                            href={`/article?id=${article.id}`}
+                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                             className="relative group cursor-pointer overflow-hidden block"
                         >
                             <Image
@@ -350,7 +350,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                         <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                     </div>
                                     <ShareButtons
-                                        url={`/article?id=${article.id}`}
+                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                         title={article.title}
                                         size="xs"
                                         className="transition-opacity"

--- a/client/components/features/dashboard/LandingNewsBlock.tsx
+++ b/client/components/features/dashboard/LandingNewsBlock.tsx
@@ -24,7 +24,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                     {articles.slice(0, 6).map((article) => (
                         <Link
                             key={article.id}
-                            href={`/article?id=${article.id}`}
+                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                             className="group cursor-pointer flex flex-col relative transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] min-w-[85vw] sm:min-w-0 snap-center"
                         >
                             <div className="aspect-video overflow-hidden mb-3 relative rounded-sm">
@@ -47,7 +47,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                                 {/* Share Icons - On Image Bottom Right */}
                                 <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                     <ShareButtons
-                                        url={`/article?id=${article.id}`}
+                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                         title={article.title}
                                         description={article.summary || article.content}
                                         size="xs"
@@ -78,7 +78,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {/* Left: Large Post */}
                     <Link
-                        href={`/article?id=${main.id}`}
+                        href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                         className="group cursor-pointer flex flex-col relative"
                     >
                         <div className="aspect-[4/3] overflow-hidden mb-4 relative rounded-sm">
@@ -101,7 +101,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                             {/* Share Icons Bottom Right */}
                             <div className="absolute bottom-3 right-3 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                 <ShareButtons
-                                    url={`/article?id=${main.id}`}
+                                    url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
                                     title={main.title}
                                     description={main.summary || main.content}
                                     size="sm"
@@ -126,7 +126,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                         {sidePosts.map((article) => (
                             <Link
                                 key={article.id}
-                                href={`/article?id=${article.id}`}
+                                href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                 className="group cursor-pointer flex gap-4 border-b border-gray-300 dark:border-gray-700 pb-4 last:border-0 last:pb-0"
                             >
                                 <div className="w-24 h-24 shrink-0 overflow-hidden relative rounded-sm">
@@ -149,7 +149,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                                     {/* Share Icons Bottom Right */}
                                     <div className="absolute bottom-1 right-1 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20 scale-75 origin-bottom-right">
                                         <ShareButtons
-                                            url={`/article?id=${article.id}`}
+                                            url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                             title={article.title}
                                             size="xs"
                                         />
@@ -181,7 +181,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                 {articles.slice(0, 4).map((article) => (
                     <Link
                         key={article.id}
-                        href={`/article?id=${article.id}`}
+                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                         className="group cursor-pointer flex flex-col border-b border-gray-300 dark:border-gray-700 pb-6 md:border-0 md:pb-0 relative"
                     >
                         <div className="aspect-[16/10] overflow-hidden mb-4 relative rounded-sm">
@@ -204,7 +204,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                             {/* Share Icons Bottom Right */}
                             <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                 <ShareButtons
-                                    url={`/article?id=${article.id}`}
+                                    url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                     title={article.title}
                                     description={article.summary || article.content}
                                     size="xs"

--- a/client/components/features/dashboard/LatestPostsSection.tsx
+++ b/client/components/features/dashboard/LatestPostsSection.tsx
@@ -34,7 +34,7 @@ export default function LatestPostsSection({ articles, title, viewAllHref }: Lat
                 {visibleArticles.map((article) => (
                     <Link
                         key={article.id}
-                        href={`/article?id=${article.id}`}
+                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                         className="group cursor-pointer flex flex-col md:flex-row gap-8 pb-10 border-b border-gray-300 dark:border-gray-700 last:border-0"
                     >
                         <div className="md:w-1/3 aspect-[4/3] shrink-0 overflow-hidden relative rounded-sm">
@@ -56,7 +56,7 @@ export default function LatestPostsSection({ articles, title, viewAllHref }: Lat
                             {/* Share Icons - Bottom Right */}
                             <div className="absolute bottom-3 right-3 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                 <ShareButtons
-                                    url={`/article?id=${article.id}`}
+                                    url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
                                     title={article.title}
                                     description={article.summary || article.content}
                                     size="xs"

--- a/client/components/features/dashboard/MostReadTodayCard.tsx
+++ b/client/components/features/dashboard/MostReadTodayCard.tsx
@@ -8,6 +8,7 @@ interface MostReadTodayProps {
   title?: string;
   items?: {
     id: number | string;
+    slug?: string;
     title: string;
     views: number;
     imageUrl: string;
@@ -27,7 +28,7 @@ export default function MostReadTodayCard({ title = "Most Read Today", items = [
         {items.map((article, index) => (
           <Link
             key={article.id}
-            href={`/article?id=${article.id}`}
+            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
             className="flex gap-4 group cursor-pointer transition-transform duration-300 hover:scale-[1.03] active:scale-[0.98]"
           >
             <div className="relative shrink-0 w-16 h-16 bg-gray-100 dark:bg-gray-800 flex items-center justify-center overflow-hidden rounded-sm transition-colors">

--- a/client/components/features/dashboard/VerticalArticleCard.tsx
+++ b/client/components/features/dashboard/VerticalArticleCard.tsx
@@ -8,6 +8,7 @@ import ShareButtons from "@/components/shared/ShareButtons";
 
 interface VerticalArticleCardProps {
     id: string;
+    slug?: string;
     title: string;
     category: string;
     location?: string;
@@ -19,6 +20,7 @@ interface VerticalArticleCardProps {
 
 export default function VerticalArticleCard({
     id,
+    slug,
     title,
     category,
     location,
@@ -29,7 +31,7 @@ export default function VerticalArticleCard({
 }: VerticalArticleCardProps) {
     return (
         <Link
-            href={`/article?id=${id}`}
+            href={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
             className="group bg-white dark:bg-[#1a1d2e] border border-[#f3f4f6] dark:border-[#2a2d3e] rounded-[12px] overflow-hidden cursor-pointer hover:shadow-md transition-shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] flex flex-col h-full"
         >
             {/* Image on top */}
@@ -54,7 +56,7 @@ export default function VerticalArticleCard({
                 {/* Share Icons - Bottom Right */}
                 <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                     <ShareButtons
-                        url={`/article?id=${id}`}
+                        url={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
                         title={title}
                         description={description}
                         size="xs"

--- a/client/lib/api-v2/admin/service/article/createArticle.ts
+++ b/client/lib/api-v2/admin/service/article/createArticle.ts
@@ -10,10 +10,17 @@ export interface StoreArticleRequest {
   content: string;
   category: string;
   country: string;
+  slug?: string;
   image?: string | null;
   status?: "published" | "pending review" | null;
   topics?: string[] | null;
   published_sites?: string[] | null;
+  author?: string;
+  date?: string;
+  gallery_images?: any[];
+  split_images?: any[];
+  content_blocks?: any[];
+  template?: string;
 }
 
 export interface CreateArticleResponse {

--- a/client/lib/api-v2/admin/service/article/updateArticle.ts
+++ b/client/lib/api-v2/admin/service/article/updateArticle.ts
@@ -10,6 +10,7 @@ export interface UpdateArticleRequest {
   content?: string | null;
   category?: string | null;
   country?: string | null;
+  slug?: string;
   image?: string | null;
   image_url?: string | null;
   status?: "published" | "pending review" | "rejected" | null;
@@ -17,6 +18,12 @@ export interface UpdateArticleRequest {
   topics?: string[] | null;
   keywords?: string | null;
   published_sites?: string[] | null;
+  author?: string;
+  date?: string;
+  gallery_images?: any[];
+  split_images?: any[];
+  content_blocks?: any[];
+  template?: string;
 }
 
 export interface UpdateArticleResponse {

--- a/client/lib/api-v2/types/ArticleResource.ts
+++ b/client/lib/api-v2/types/ArticleResource.ts
@@ -14,6 +14,7 @@ export interface ArticleResource {
   original_url: string;
   created_at: string;
   published_sites: string | string[];
+  slug?: string;
   image_url?: string;
   is_deleted?: boolean;
 }

--- a/server/app/Http/Controllers/Api/User/ArticleController.php
+++ b/server/app/Http/Controllers/Api/User/ArticleController.php
@@ -150,7 +150,11 @@ class ArticleController extends Controller
         // Eager load relationships to prevent N+1
         $article = Article::with(['publishedSites:id,site_name', 'images:article_id,image_path'])
             ->where('is_deleted', false)
-            ->find($id);
+            ->where(function ($query) use ($id) {
+                $query->where('id', $id)
+                    ->orWhere('slug', $id);
+            })
+            ->first();
 
         if (! $article) {
             // Fallback to Redis if not found in DB
@@ -170,7 +174,9 @@ class ArticleController extends Controller
      */
     public function incrementViews(string $id): JsonResponse
     {
-        $article = Article::find($id);
+        $article = Article::where('id', $id)
+            ->orWhere('slug', $id)
+            ->first();
 
         if (! $article) {
             return response()->json(['error' => 'Article not found'], 404);

--- a/server/app/Http/Resources/Articles/ArticleResource.php
+++ b/server/app/Http/Resources/Articles/ArticleResource.php
@@ -87,6 +87,7 @@ class ArticleResource extends JsonResource
 
         return [
             'id' => (string) $get('id', ''),
+            'slug' => (string) $get('slug', ''),
             'article_id' => (string) $get('article_id', $get('id', '')),
             'title' => (string) $get('title', ''),
             'summary' => (string) $get('summary', $get('content', '')),


### PR DESCRIPTION
refactor(article): implement slug-based redirects and dual ID/Slug support for views

### Summary
This PR improves SEO by ensuring that articles are primarily accessed via their URL slugs. It introduces a server-side redirect on the client for legacy ID-based links and updates the backend to support both IDs and Slugs for administrative actions like view incrementing.

### Implementation
**Frontend:**
- **SEO Redirect**: Updated `app/(landing)/article/page.tsx` to detect if an article is accessed via a numeric ID. If a slug exists for that article, it now automatically redirects to the prettier URL (`/article?slug=...`).
- **Data Fetching**: Integrated `getArticleById` into the redirect logic to safely verify slug existence before jumping.

**Backend:**
- **Controller Refinement**: Updated `ArticleController.php@incrementViews` to perform a dual lookup. It now correctly identifies articles whether they are passed by numeric ID or descriptive slug, ensuring view counts are accurate regardless of the incoming link format.

### Testing
**Manual:**
1. Navigate to an article using an ID-based link (e.g., `/article?id=123`).
2. Verify that you are automatically redirected to `/article?slug=your-article-title`.
3. Check the network tab to ensure a 302/307 redirect occurred.
4. Verify that clicking/viewing the article still increments the view count in the database (test via API or Admin dashboard).