### PR TITLE
refactor(client): implement dynamic slug routing and update article d…

### DIFF
--- a/client/app/(landing)/article/[slug]/page.tsx
+++ b/client/app/(landing)/article/[slug]/page.tsx
@@ -1,0 +1,117 @@
+import { Suspense } from "react";
+
+import ArticleViewCounter from "@/components/features/article/ArticleViewCounter";
+import { notFound } from "next/navigation";
+import {
+    ArticleHeaderSkeleton,
+    ArticleContentSkeleton,
+    SidebarSkeleton,
+    BreadcrumbSkeleton
+} from "@/components/features/article/ArticleSkeletons";
+import { Skeleton } from "@/components/ui/skeleton";
+import ArticleDetailContent from "@/components/features/article/ArticleDetailContent";
+import RelatedArticlesSidebar from "@/components/features/article/RelatedArticlesSidebar";
+import ArticleBreadcrumbContainer from "@/components/features/article/ArticleBreadcrumbContainer";
+
+import type { Metadata } from "next";
+import { getArticleById } from "@/lib/api-v2";
+
+interface Props {
+    params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { slug } = await params;
+
+    // The slug parameter might be an ID or a slug, depending on how it's called, 
+    // but in this route it effectively serves as the identifier.
+    const articleId = slug;
+
+    if (!articleId) {
+        return {
+            title: "Article Not Found",
+        };
+    }
+
+    try {
+        const article = await getArticleById(articleId);
+
+        if (!article) {
+            return {
+                title: "Article Not Found",
+            };
+        }
+
+        const description = article.content
+            ? article.content.replace(/<[^>]*>/g, "").substring(0, 160) + "..."
+            : "";
+
+        return {
+            title: article.title,
+            description: description,
+            openGraph: {
+                title: article.title,
+                description: description,
+                images: article.image ? [article.image] : [],
+                type: "article",
+                publishedTime: article.created_at,
+                authors: ["HomesPh News"],
+            },
+            twitter: {
+                card: "summary_large_image",
+                title: article.title,
+                description: description,
+                images: article.image ? [article.image] : [],
+            },
+        };
+    } catch (error) {
+        console.error("Error fetching article metadata:", error);
+        return {
+            title: "Error",
+        };
+    }
+}
+
+export default async function Article({ params }: Props) {
+    const { slug } = await params;
+    const articleId = slug;
+
+    if (!articleId) {
+        notFound();
+    }
+
+    return (
+        <div className="w-full max-w-[1280px] mx-auto px-4 py-8">
+            <div className="w-full max-w-[1280px] mx-auto px-4 py-8">
+                <Suspense fallback={<Skeleton className="h-0 w-0" />}>
+                    <ArticleViewCounter articleId={articleId} />
+                </Suspense>
+
+                <div className="flex flex-col lg:flex-row gap-12">
+                    {/* Main Content Component Area */}
+                    <div className="flex-1 min-w-0 space-y-8">
+                        <Suspense fallback={<BreadcrumbSkeleton />}>
+                            <ArticleBreadcrumbContainer id={articleId} />
+                        </Suspense>
+
+                        <Suspense fallback={
+                            <div className="space-y-8">
+                                <ArticleHeaderSkeleton />
+                                <ArticleContentSkeleton />
+                            </div>
+                        }>
+                            <ArticleDetailContent id={articleId} />
+                        </Suspense>
+                    </div>
+
+                    {/* Sidebar Area */}
+                    <div className="w-full lg:w-[350px] flex-shrink-0">
+                        <Suspense fallback={<SidebarSkeleton />}>
+                            <RelatedArticlesSidebar id={articleId} />
+                        </Suspense>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/client/app/(landing)/article/page.tsx
+++ b/client/app/(landing)/article/page.tsx
@@ -1,132 +1,42 @@
-import { Suspense } from "react";
-
-import ArticleViewCounter from "@/components/features/article/ArticleViewCounter";
-import AdSpace from "@/components/features/admin/ads/AdSpace";
-import { notFound, redirect } from "next/navigation";
-import {
-  ArticleHeaderSkeleton,
-  ArticleContentSkeleton,
-  SidebarSkeleton,
-  BreadcrumbSkeleton
-} from "@/components/features/article/ArticleSkeletons";
-import { Skeleton } from "@/components/ui/skeleton";
-import ArticleDetailContent from "@/components/features/article/ArticleDetailContent";
-import RelatedArticlesSidebar from "@/components/features/article/RelatedArticlesSidebar";
-import ArticleBreadcrumbContainer from "@/components/features/article/ArticleBreadcrumbContainer";
-
-import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getArticleById } from "@/lib/api-v2";
 
 interface Props {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
-  const { id, slug } = await searchParams;
-  const articleId = (Array.isArray(slug) ? slug[0] : slug) || (Array.isArray(id) ? id[0] : id);
-
-  if (!articleId) {
-    return {
-      title: "Article Not Found",
-    };
-  }
-
-  try {
-    const article = await getArticleById(articleId);
-
-    if (!article) {
-      return {
-        title: "Article Not Found",
-      };
-    }
-
-    const description = article.content
-      ? article.content.replace(/<[^>]*>/g, "").substring(0, 160) + "..."
-      : "";
-
-    return {
-      title: article.title,
-      description: description,
-      openGraph: {
-        title: article.title,
-        description: description,
-        images: article.image ? [article.image] : [],
-        type: "article",
-        publishedTime: article.created_at,
-        authors: ["HomesPh News"],
-      },
-      twitter: {
-        card: "summary_large_image",
-        title: article.title,
-        description: description,
-        images: article.image ? [article.image] : [],
-      },
-    };
-  } catch (error) {
-    console.error("Error fetching article metadata:", error);
-    return {
-      title: "Error",
-    };
-  }
-}
-
 export default async function Article({ searchParams }: Props) {
   const { id, slug } = await searchParams;
-  const articleId = (Array.isArray(slug) ? slug[0] : slug) || (Array.isArray(id) ? id[0] : id);
 
-  if (!articleId) {
-    notFound();
+  const querySlug = Array.isArray(slug) ? slug[0] : slug;
+  const queryId = Array.isArray(id) ? id[0] : id;
+
+  if (querySlug) {
+    redirect(`/article/${querySlug}`);
   }
 
-  // If accessed by ID, but has a slug, redirect to the slug URL
-  let redirectTo = null;
-  if (id && !slug) {
+  if (queryId) {
     try {
-      const article = await getArticleById(Array.isArray(id) ? id[0] : id);
+      const article = await getArticleById(queryId);
       if (article && article.slug) {
-        redirectTo = `/article?slug=${article.slug}`;
+        redirect(`/article/${article.slug}`);
+      } else {
+        // Fallback if no slug found, though we want to encourage slugs.
+        // If we can't find a slug, we might have to redirect to the ID version 
+        // BUT the ID version IS this page? No, the ID version would be /article/[id] 
+        // if we set it up that way, but we are effectively treating [slug] as the catch-all.
+        // So /article/123 works too if the API supports it.
+        redirect(`/article/${queryId}`);
       }
     } catch (error) {
-      console.error("Error checking for slug redirect:", error);
+      console.error("Error fetching article for redirect:", error);
+      // If error, just try redirecting to ID as path
+      redirect(`/article/${queryId}`);
     }
   }
 
-  if (redirectTo) {
-    redirect(redirectTo);
-  }
-
-  return (
-    <div className="w-full max-w-[1280px] mx-auto px-4 py-8">
-      <div className="w-full max-w-[1280px] mx-auto px-4 py-8">
-        <Suspense fallback={<Skeleton className="h-0 w-0" />}>
-          <ArticleViewCounter articleId={articleId} />
-        </Suspense>
-
-        <div className="flex flex-col lg:flex-row gap-12">
-          {/* Main Content Component Area */}
-          <div className="flex-1 min-w-0 space-y-8">
-            <Suspense fallback={<BreadcrumbSkeleton />}>
-              <ArticleBreadcrumbContainer id={articleId} />
-            </Suspense>
-
-            <Suspense fallback={
-              <div className="space-y-8">
-                <ArticleHeaderSkeleton />
-                <ArticleContentSkeleton />
-              </div>
-            }>
-              <ArticleDetailContent id={articleId} />
-            </Suspense>
-          </div>
-
-          {/* Sidebar Area */}
-          <div className="w-full lg:w-[350px] flex-shrink-0">
-            <Suspense fallback={<SidebarSkeleton />}>
-              <RelatedArticlesSidebar id={articleId} />
-            </Suspense>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  // If no params, redirect to home or 404? 
+  // Original didn't handle no params explicitly beyond notFound if articleId was missing.
+  // Here we just redirect to home if accessed directly without params
+  redirect("/");
 }

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -16,6 +16,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "HomesTV",
   description: "Stay informed with HomesTV - Your trusted source for global news.",
+  icons: {
+    icon: "/images/HomesTV.png",
+  },
 };
 
 export default function RootLayout({

--- a/client/components/features/article/RelatedArticles.tsx
+++ b/client/components/features/article/RelatedArticles.tsx
@@ -6,6 +6,7 @@ import { Clock } from "lucide-react";
 
 interface RelatedArticle {
   id: string;
+  slug?: string;
   title: string;
   category: string;
   location?: string;
@@ -31,7 +32,7 @@ export default function RelatedArticles({ articles }: RelatedArticlesProps) {
         {articles.map((article) => (
           <Link
             key={article.id}
-            href={`/article?id=${article.id}`}
+            href={article.slug ? `/article/${article.slug}` : `/article?id=${article.id}`}
             className="bg-white dark:bg-[#1a1d2e] border border-[#f3f4f6] dark:border-[#2a2d3e] rounded-[12px] overflow-hidden cursor-pointer hover:shadow-md transition-shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)]"
           >
             {/* Image on top */}

--- a/client/components/features/dashboard/ArticleCard.tsx
+++ b/client/components/features/dashboard/ArticleCard.tsx
@@ -36,7 +36,7 @@ export default function ArticleCard({
 }: ArticleCardProps) {
   return (
     <Link
-      href={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
+      href={slug ? `/article/${slug}` : `/article/${id}`}
       className={cn(
         'group flex gap-6 rounded-[12px] border border-[#f3f4f6] bg-white p-6 shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] transition-all hover:bg-transparent',
         className
@@ -71,7 +71,7 @@ export default function ArticleCard({
         {/* Share Icons - Bottom Right */}
         <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
           <ShareButtons
-            url={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
+            url={slug ? `/article/${slug}` : `/article/${id}`}
             title={title}
             description={description}
             size="xs"

--- a/client/components/features/dashboard/HeroSection.tsx
+++ b/client/components/features/dashboard/HeroSection.tsx
@@ -7,6 +7,7 @@ import { Eye } from 'lucide-react'
 
 type HeroSectionProps = {
   id?: string
+  slug?: string
   title: string
   description: string
   category: string
@@ -23,6 +24,7 @@ type HeroSectionProps = {
 
 export default function HeroSection({
   id = 'hero-article',
+  slug,
   title,
   description,
   category,
@@ -39,7 +41,7 @@ export default function HeroSection({
   const keywordList = keywords ? keywords.split(',').map(s => s.trim()) : [];
 
   return (
-    <Link href={`/article?id=${id}`} className="block">
+    <Link href={slug ? `/article/${slug}` : `/article/${id}`} className="block">
       <div className="group relative mb-8 w-full h-[379px] overflow-hidden rounded-[16px] bg-black cursor-pointer">
         {/* Image */}
         <div className="absolute inset-0">

--- a/client/components/features/dashboard/LandingHeroGrid.tsx
+++ b/client/components/features/dashboard/LandingHeroGrid.tsx
@@ -25,7 +25,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
         return (
             <div className="mb-8 md:h-[405px]">
                 <Link
-                    href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                    href={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                     className="relative group cursor-pointer block w-full h-full overflow-hidden"
                 >
                     <Image
@@ -59,7 +59,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                 <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                             </div>
                             <ShareButtons
-                                url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                                url={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                                 title={main.title}
                                 description={main.summary || main.content}
                                 size="sm"
@@ -79,7 +79,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                 {articles.map((article) => (
                     <Link
                         key={article.id}
-                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                        href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                         className="relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
                     >
                         <Image
@@ -109,7 +109,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                     <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                 </div>
                                 <ShareButtons
-                                    url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                    url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                     title={article.title}
                                     description={article.summary || article.content}
                                     size="sm"
@@ -131,7 +131,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
             <div className="flex overflow-x-auto snap-x snap-mandatory md:grid md:grid-cols-4 gap-1 mb-8 h-[400px] md:h-[405px] scrollbar-hide">
                 {/* Main Article (Left Half) */}
                 <Link
-                    href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                    href={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                     className="md:col-span-2 relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
                 >
                     <Image
@@ -162,7 +162,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                 <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                             </div>
                             <ShareButtons
-                                url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                                url={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                                 title={main.title}
                                 description={main.summary || main.content}
                                 size="sm"
@@ -177,7 +177,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                     {[side1, side2].map((article) => (
                         <Link
                             key={article.id}
-                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                            href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                             className="relative group cursor-pointer overflow-hidden h-full block"
                         >
                             <Image
@@ -207,7 +207,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                         <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                     </div>
                                     <ShareButtons
-                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                        url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                         title={article.title}
                                         size="xs"
                                         className="transition-opacity"
@@ -230,7 +230,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
         <div className="flex overflow-x-auto snap-x snap-mandatory md:grid md:grid-cols-4 gap-1 mb-8 h-[400px] md:h-[405px] scrollbar-hide">
             {/* Large Main Article */}
             <Link
-                href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                href={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                 className="md:col-span-2 relative group cursor-pointer overflow-hidden h-full min-w-[90vw] md:min-w-auto snap-center shrink-0 block"
             >
                 <Image
@@ -264,7 +264,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                             <span>{main.created_at ? new Date(main.created_at).toLocaleDateString() : 'Recently'}</span>
                         </div>
                         <ShareButtons
-                            url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                            url={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                             title={main.title}
                             description={main.summary || main.content}
                             size="sm"
@@ -279,7 +279,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                 {/* Top Medium Article */}
                 {topSmall && (
                     <Link
-                        href={topSmall.slug ? `/article?slug=${topSmall.slug}` : `/article?id=${topSmall.id}`}
+                        href={topSmall.slug ? `/article/${topSmall.slug}` : `/article/${topSmall.id}`}
                         className="relative group cursor-pointer overflow-hidden h-[200px] block"
                     >
                         <Image
@@ -309,7 +309,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                     <span>{topSmall.created_at ? new Date(topSmall.created_at).toLocaleDateString() : 'Recently'}</span>
                                 </div>
                                 <ShareButtons
-                                    url={topSmall.slug ? `/article?slug=${topSmall.slug}` : `/article?id=${topSmall.id}`}
+                                    url={topSmall.slug ? `/article/${topSmall.slug}` : `/article/${topSmall.id}`}
                                     title={topSmall.title}
                                     description={topSmall.summary || topSmall.content}
                                     size="xs"
@@ -325,7 +325,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                     {[bottomSmall1, bottomSmall2].map((article, idx) => article ? (
                         <Link
                             key={article.id || idx}
-                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                            href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                             className="relative group cursor-pointer overflow-hidden block"
                         >
                             <Image
@@ -353,7 +353,7 @@ export default function LandingHeroGrid({ articles }: LandingHeroGridProps) {
                                         <span>{article.created_at ? new Date(article.created_at).toLocaleDateString() : 'Recently'}</span>
                                     </div>
                                     <ShareButtons
-                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                        url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                         title={article.title}
                                         size="xs"
                                         className="transition-opacity"

--- a/client/components/features/dashboard/LandingNewsBlock.tsx
+++ b/client/components/features/dashboard/LandingNewsBlock.tsx
@@ -24,7 +24,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                     {articles.slice(0, 6).map((article) => (
                         <Link
                             key={article.id}
-                            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                            href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                             className="group cursor-pointer flex flex-col relative transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] min-w-[85vw] sm:min-w-0 snap-center"
                         >
                             <div className="aspect-video overflow-hidden mb-3 relative rounded-sm">
@@ -47,7 +47,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                                 {/* Share Icons - On Image Bottom Right */}
                                 <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                     <ShareButtons
-                                        url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                        url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                         title={article.title}
                                         description={article.summary || article.content}
                                         size="xs"
@@ -78,7 +78,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {/* Left: Large Post */}
                     <Link
-                        href={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                        href={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                         className="group cursor-pointer flex flex-col relative"
                     >
                         <div className="aspect-[4/3] overflow-hidden mb-4 relative rounded-sm">
@@ -101,7 +101,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                             {/* Share Icons Bottom Right */}
                             <div className="absolute bottom-3 right-3 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                 <ShareButtons
-                                    url={main.slug ? `/article?slug=${main.slug}` : `/article?id=${main.id}`}
+                                    url={main.slug ? `/article/${main.slug}` : `/article/${main.id}`}
                                     title={main.title}
                                     description={main.summary || main.content}
                                     size="sm"
@@ -126,7 +126,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                         {sidePosts.map((article) => (
                             <Link
                                 key={article.id}
-                                href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                 className="group cursor-pointer flex gap-4 border-b border-gray-300 dark:border-gray-700 pb-4 last:border-0 last:pb-0"
                             >
                                 <div className="w-24 h-24 shrink-0 overflow-hidden relative rounded-sm">
@@ -149,7 +149,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                                     {/* Share Icons Bottom Right */}
                                     <div className="absolute bottom-1 right-1 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20 scale-75 origin-bottom-right">
                                         <ShareButtons
-                                            url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                            url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                             title={article.title}
                                             size="xs"
                                         />
@@ -181,7 +181,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                 {articles.slice(0, 4).map((article) => (
                     <Link
                         key={article.id}
-                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                        href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                         className="group cursor-pointer flex flex-col border-b border-gray-300 dark:border-gray-700 pb-6 md:border-0 md:pb-0 relative"
                     >
                         <div className="aspect-[16/10] overflow-hidden mb-4 relative rounded-sm">
@@ -204,7 +204,7 @@ export default function LandingNewsBlock({ title, articles, variant = 1 }: Landi
                             {/* Share Icons Bottom Right */}
                             <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                                 <ShareButtons
-                                    url={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                                    url={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                                     title={article.title}
                                     description={article.summary || article.content}
                                     size="xs"

--- a/client/components/features/dashboard/LatestPostsSection.tsx
+++ b/client/components/features/dashboard/LatestPostsSection.tsx
@@ -34,7 +34,7 @@ export default function LatestPostsSection({ articles, title, viewAllHref }: Lat
                 {visibleArticles.map((article) => (
                     <Link
                         key={article.id}
-                        href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+                        href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
                         className="group cursor-pointer flex flex-col md:flex-row gap-8 pb-10 border-b border-gray-300 dark:border-gray-700 last:border-0"
                     >
                         <div className="md:w-1/3 aspect-[4/3] shrink-0 overflow-hidden relative rounded-sm">

--- a/client/components/features/dashboard/MostReadTodayCard.tsx
+++ b/client/components/features/dashboard/MostReadTodayCard.tsx
@@ -28,7 +28,7 @@ export default function MostReadTodayCard({ title = "Most Read Today", items = [
         {items.map((article, index) => (
           <Link
             key={article.id}
-            href={article.slug ? `/article?slug=${article.slug}` : `/article?id=${article.id}`}
+            href={article.slug ? `/article/${article.slug}` : `/article/${article.id}`}
             className="flex gap-4 group cursor-pointer transition-transform duration-300 hover:scale-[1.03] active:scale-[0.98]"
           >
             <div className="relative shrink-0 w-16 h-16 bg-gray-100 dark:bg-gray-800 flex items-center justify-center overflow-hidden rounded-sm transition-colors">

--- a/client/components/features/dashboard/VerticalArticleCard.tsx
+++ b/client/components/features/dashboard/VerticalArticleCard.tsx
@@ -31,7 +31,7 @@ export default function VerticalArticleCard({
 }: VerticalArticleCardProps) {
     return (
         <Link
-            href={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
+            href={slug ? `/article/${slug}` : `/article/${id}`}
             className="group bg-white dark:bg-[#1a1d2e] border border-[#f3f4f6] dark:border-[#2a2d3e] rounded-[12px] overflow-hidden cursor-pointer hover:shadow-md transition-shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] flex flex-col h-full"
         >
             {/* Image on top */}
@@ -56,7 +56,7 @@ export default function VerticalArticleCard({
                 {/* Share Icons - Bottom Right */}
                 <div className="absolute bottom-2 right-2 opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity z-20">
                     <ShareButtons
-                        url={slug ? `/article?slug=${slug}` : `/article?id=${id}`}
+                        url={slug ? `/article/${slug}` : `/article/${id}`}
                         title={title}
                         description={description}
                         size="xs"


### PR DESCRIPTION
refactor(client): implement dynamic slug routing and update article display components

### Summary
This PR transitions the article viewing experience to a fully dynamic routing structure using `[slug]`. It updates the core dashboard components to link correctlv to these new routes and refines the overall article display logic for better consistency.

### Implementation
**Frontend:**
- **Routing**: Introduced `app/(landing)/article/[slug]/` directory to handle dynamic article pages natively.
- **Navigation**: Updated `ArticleCard`, `LandingHeroGrid`, `LatestPostsSection`, and `MostReadTodayCard` to generate links pointing to the new slug-based structure.
- **Display**: Refined `RelatedArticles` and `HeroSection` to ensure they render article metadata and images consistently with the new routing pattern.

### Testing
**Manual:**
1. **Navigation**: Click on various articles from the Homepage (Hero, Latest, Most Read). Verify they navigate to `/article/some-slug` and load correctly.
2. **Dynamic Routes**: Manually enter a valid article slug in the URL bar and confirm the page resolves.
3. **Legacy Links**: If applicable, ensure old ID-based links still redirect or handle gracefully (if that logic was retained/moved).