### PR TITLE
refactor(client): optimize ad placement logic for structured content …

### DIFF
--- a/client/components/features/article/ArticleContent.tsx
+++ b/client/components/features/article/ArticleContent.tsx
@@ -33,13 +33,15 @@ export default function ArticleContent({ content, contentBlocks, topics, origina
         }
       `}</style>
 
-      {/* Advertisement Top */}
-      <AdSpace
-        className="mb-6"
-        width={728}
-        height={90}
-        rotateInterval={10000}
-      />
+      {/* Advertisement Top - Only for legacy content */}
+      {!hasContentBlocks && (
+        <AdSpace
+          className="mb-6"
+          width={728}
+          height={90}
+          rotateInterval={10000}
+        />
+      )}
 
       {/* Main Content Area */}
       <div className="prose prose-lg max-w-none mb-12">
@@ -57,112 +59,124 @@ export default function ArticleContent({ content, contentBlocks, topics, origina
               } as React.CSSProperties;
 
               return (
-                <div key={block.id || idx} className="mb-10">
-                  {/* 1. TEXT */}
-                  {type === 'text' && (
-                    <div
-                      style={blockStyle}
-                      className={cn(
-                        "text-[18px] leading-[32px] tracking-[-0.5px] [&>h1]:text-3xl [&>h1]:font-bold [&>h1]:mb-6 [&>h2]:text-2xl [&>h2]:font-bold [&>h2]:mb-4",
-                        darkClass("text-[#0c0c0c] dark:text-gray-100"),
-                        settings?.listType === 'bullet' && "list-disc ml-8",
-                        settings?.listType === 'number' && "list-decimal ml-8",
-                        idx === 0 && "drop-cap"
-                      )}
-                      dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
-                    />
-                  )}
-
-                  {/* 2. IMAGES */}
-                  {(type === 'image' || type === 'centered-image') && (
-                    <figure className={cn("my-10", type === 'centered-image' && "max-w-[90%] mx-auto")}>
-                      <img
-                        src={bContent?.src || block.image}
-                        alt={bContent?.caption || block.caption || ""}
-                        className="w-full rounded-2xl shadow-lg border border-gray-100/10"
+                <div key={block.id || idx}>
+                  <div className="mb-10">
+                    {/* 1. TEXT */}
+                    {type === 'text' && (
+                      <div
+                        style={blockStyle}
+                        className={cn(
+                          "text-[18px] leading-[32px] tracking-[-0.5px] [&>h1]:text-3xl [&>h1]:font-bold [&>h1]:mb-6 [&>h2]:text-2xl [&>h2]:font-bold [&>h2]:mb-4",
+                          darkClass("text-[#0c0c0c] dark:text-gray-100"),
+                          settings?.listType === 'bullet' && "list-disc ml-8",
+                          settings?.listType === 'number' && "list-decimal ml-8",
+                          idx === 0 && "drop-cap"
+                        )}
+                        dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
                       />
-                      {(bContent?.caption || block.caption) && (
-                        <figcaption className={cn("text-sm text-center mt-4 italic", darkClass("text-gray-500 dark:text-gray-400"))}>
-                          {bContent?.caption || block.caption}
-                        </figcaption>
-                      )}
-                    </figure>
-                  )}
+                    )}
 
-                  {/* 3. SIDE IMAGES */}
-                  {(type === 'left-image' || type === 'right-image') && (
-                    <div className={cn(
-                      "my-12 flex gap-10 items-start flex-col md:flex-row",
-                      type === 'right-image' && "md:flex-row-reverse"
-                    )}>
-                      <div className="w-full md:w-[280px] shrink-0">
+                    {/* 2. IMAGES */}
+                    {(type === 'image' || type === 'centered-image') && (
+                      <figure className={cn("my-10", type === 'centered-image' && "max-w-[90%] mx-auto")}>
                         <img
-                          src={bContent?.image || bContent?.src || block.image}
-                          alt=""
-                          className="w-full aspect-square object-cover rounded-2xl shadow-md"
+                          src={bContent?.src || block.image}
+                          alt={bContent?.caption || block.caption || ""}
+                          className="w-full rounded-2xl shadow-lg border border-gray-100/10"
                         />
                         {(bContent?.caption || block.caption) && (
-                          <p className={cn("text-xs mt-3 italic text-center leading-tight", darkClass("text-gray-400"))}>
+                          <figcaption className={cn("text-sm text-center mt-4 italic", darkClass("text-gray-500 dark:text-gray-400"))}>
                             {bContent?.caption || block.caption}
-                          </p>
+                          </figcaption>
                         )}
-                      </div>
-                      <div
-                        style={blockStyle}
-                        className={cn("flex-1 text-[18px] leading-[34px]", darkClass("text-[#0c0c0c] dark:text-gray-200"))}
-                        dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
-                      />
-                    </div>
-                  )}
+                      </figure>
+                    )}
 
-                  {/* 4. GRIDS */}
-                  {type === 'grid' && (
-                    <div className={cn(
-                      "my-10 grid gap-6",
-                      (bContent?.images?.length === 3) ? "grid-cols-3" : "grid-cols-2"
-                    )}>
-                      {bContent?.images?.map((img: string, i: number) => (
-                        <img
-                          key={i}
-                          src={img}
-                          className="w-full aspect-square object-cover rounded-2xl shadow-sm hover:scale-[1.02] transition-transform duration-300"
-                        />
-                      ))}
-                    </div>
-                  )}
-
-                  {/* 5. SPLIT VIEW */}
-                  {(type === 'split-left' || type === 'split-right') && (
-                    <div className={cn(
-                      "my-12 flex flex-col md:flex-row rounded-3xl overflow-hidden min-h-[450px] shadow-sm border border-gray-100/10",
-                      darkClass("bg-gray-50 dark:bg-white/5"),
-                      type === 'split-right' && "md:flex-row-reverse"
-                    )}>
-                      <div className="flex-1 min-h-[350px]">
-                        <img
-                          src={bContent?.image || block.image}
-                          className="w-full h-full object-cover"
+                    {/* 3. SIDE IMAGES */}
+                    {(type === 'left-image' || type === 'right-image') && (
+                      <div className={cn(
+                        "my-12 flex gap-10 items-start flex-col md:flex-row",
+                        type === 'right-image' && "md:flex-row-reverse"
+                      )}>
+                        <div className="w-full md:w-[280px] shrink-0">
+                          <img
+                            src={bContent?.image || bContent?.src || block.image}
+                            alt=""
+                            className="w-full aspect-square object-cover rounded-2xl shadow-md"
+                          />
+                          {(bContent?.caption || block.caption) && (
+                            <p className={cn("text-xs mt-3 italic text-center leading-tight", darkClass("text-gray-400"))}>
+                              {bContent?.caption || block.caption}
+                            </p>
+                          )}
+                        </div>
+                        <div
+                          style={blockStyle}
+                          className={cn("flex-1 text-[18px] leading-[34px]", darkClass("text-[#0c0c0c] dark:text-gray-200"))}
+                          dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
                         />
                       </div>
-                      <div
-                        style={blockStyle}
-                        className={cn("flex-1 p-10 md:p-14 flex items-center text-[22px] leading-[1.4] font-medium tracking-tight", darkClass("text-[#111827] dark:text-white"))}
-                        dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
-                      />
-                    </div>
-                  )}
+                    )}
 
-                  {/* 6. DYNAMIC IMAGES */}
-                  {type === 'dynamic-images' && (
-                    <div className="my-10 space-y-6">
-                      {bContent?.images?.map((img: string, i: number) => (
-                        <img
-                          key={i}
-                          src={img}
-                          className="w-full rounded-2xl shadow-md"
+                    {/* 4. GRIDS */}
+                    {type === 'grid' && (
+                      <div className={cn(
+                        "my-10 grid gap-6",
+                        (bContent?.images?.length === 3) ? "grid-cols-3" : "grid-cols-2"
+                      )}>
+                        {bContent?.images?.map((img: string, i: number) => (
+                          <img
+                            key={i}
+                            src={img}
+                            className="w-full aspect-square object-cover rounded-2xl shadow-sm hover:scale-[1.02] transition-transform duration-300"
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {/* 5. SPLIT VIEW */}
+                    {(type === 'split-left' || type === 'split-right') && (
+                      <div className={cn(
+                        "my-12 flex flex-col md:flex-row rounded-3xl overflow-hidden min-h-[450px] shadow-sm border border-gray-100/10",
+                        darkClass("bg-gray-50 dark:bg-white/5"),
+                        type === 'split-right' && "md:flex-row-reverse"
+                      )}>
+                        <div className="flex-1 min-h-[350px]">
+                          <img
+                            src={bContent?.image || block.image}
+                            className="w-full h-full object-cover"
+                          />
+                        </div>
+                        <div
+                          style={blockStyle}
+                          className={cn("flex-1 p-10 md:p-14 flex items-center text-[22px] leading-[1.4] font-medium tracking-tight", darkClass("text-[#111827] dark:text-white"))}
+                          dangerouslySetInnerHTML={{ __html: decodeHtml(bContent?.text || bContent || '') }}
                         />
-                      ))}
-                    </div>
+                      </div>
+                    )}
+
+                    {/* 6. DYNAMIC IMAGES */}
+                    {type === 'dynamic-images' && (
+                      <div className="my-10 space-y-6">
+                        {bContent?.images?.map((img: string, i: number) => (
+                          <img
+                            key={i}
+                            src={img}
+                            className="w-full rounded-2xl shadow-md"
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Ad after first block */}
+                  {idx === 0 && (
+                    <AdSpace
+                      className="my-10"
+                      width={728}
+                      height={90}
+                      rotateInterval={10000}
+                    />
                   )}
                 </div>
               );


### PR DESCRIPTION
refactor(client): optimize ad placement logic for structured content blocks

### Summary
This PR refactors the [ArticleContent](cci:1://file:///c:/Users/postr/Desktop/HomesPhNews/client/components/features/article/ArticleContent.tsx:13:0-252:1) component to intelligently handle ad placement based on the content type. It ensures that for new structured content blocks, the ad appears organically after the first block, while maintaining the traditional top-placement for legacy HTML content.

### Implementation
**Frontend:**
- **ArticleContent.tsx**:
    - Implemented a conditional check for `hasContentBlocks`.
    - **Legacy Mode**: If no blocks are present, the `AdSpace` remains at the top of the article.
    - **Block Mode**: If blocks exist, the `AdSpace` is injected specifically after the first content block (index 0) to improve viewability without pushing down the initial hook.

### Testing
**Manual:**
1. **Legacy Article**: Open an older article (HTML-only) and verify the ad appears immediately below the header, before the text.
2. **New Article**: Open an article created with the new editor (Blocks). Verify the ad does *not* appear at the very top, but instead renders after the first paragraph or image block.