### PR TITLE
Dynamic Admin Article Filters & Restaurant Data Exclusion

### DIFF
--- a/client/app/admin/articles/page.tsx
+++ b/client/app/admin/articles/page.tsx
@@ -22,12 +22,12 @@ const URL_FILTERS_CONFIG = {
         resetValues: ['all']
     },
     category: {
-        default: 'All Category' as const,
-        resetValues: ['All Category']
+        default: '' as const,
+        resetValues: ['']
     },
     country: {
-        default: 'All Countries' as const,
-        resetValues: ['All Countries']
+        default: '' as const,
+        resetValues: ['']
     },
 };
 
@@ -51,6 +51,15 @@ export default function ArticlesPage() {
     const [filteredArticles, setFilteredArticles] = useState<ArticleResource[]>([]);
     const [isLoading, setIsLoading] = useState(true);
 
+    // State for available filters (categories/countries from backend)
+    const [availableFilters, setAvailableFilters] = useState<{
+        categories: string[];
+        countries: string[];
+    }>({
+        categories: [],
+        countries: [],
+    });
+
     // State for status counts (from backend)
     const [counts, setCounts] = useState({
         all: 0,
@@ -58,8 +67,6 @@ export default function ArticlesPage() {
         pending: 0,
         deleted: 0,
     });
-
-    // Effect: Fetch articles when filters change
     useEffect(() => {
         const fetchArticles = async () => {
             setIsLoading(true);
@@ -68,8 +75,8 @@ export default function ArticlesPage() {
                 // Status 'pending' will trigger the Redis fetch on the backend
                 const apiFilters = {
                     status: filters.status === 'all' ? undefined : filters.status,
-                    category: filters.category === 'All Category' ? undefined : filters.category,
-                    country: filters.country === 'All Countries' ? undefined : filters.country,
+                    category: filters.category === '' ? undefined : filters.category,
+                    country: filters.country === '' ? undefined : filters.country,
                     search: searchQuery || undefined,
                     page: pagination.currentPage,
                     per_page: 10
@@ -77,7 +84,7 @@ export default function ArticlesPage() {
 
                 const response = await getAdminArticles(apiFilters);
                 // Backend returns pagination fields at top level, not in a meta object
-                const { data, current_page, last_page, status_counts } = response.data;
+                const { data, current_page, last_page, status_counts, available_filters } = response.data;
 
                 // Ensure we always have an array, even if API returns unexpected data
                 setFilteredArticles(data ?? []);
@@ -94,6 +101,11 @@ export default function ArticlesPage() {
                         pending: Number(status_counts.pending),
                         deleted: Number(status_counts.deleted || 0),
                     });
+                }
+
+                // Update available filters from backend
+                if (available_filters) {
+                    setAvailableFilters(available_filters);
                 }
 
             } catch (error) {
@@ -139,6 +151,8 @@ export default function ArticlesPage() {
                     setCategoryFilter={(cat) => setFilter('category', cat)}
                     countryFilter={filters.country}
                     setCountryFilter={(country) => setFilter('country', country)}
+                    availableCategories={availableFilters.categories}
+                    availableCountries={availableFilters.countries}
                 />
 
                 <div className="flex flex-col">

--- a/client/components/features/admin/articles/ArticlesFilters.tsx
+++ b/client/components/features/admin/articles/ArticlesFilters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Search, ChevronDown } from 'lucide-react';
-import { Categories, Countries } from "@/app/data";
 
 interface ArticlesFiltersProps {
     searchQuery: string;
@@ -10,10 +9,12 @@ interface ArticlesFiltersProps {
     setCategoryFilter: (category: string) => void;
     countryFilter: string;
     setCountryFilter: (country: string) => void;
+    availableCategories?: string[];
+    availableCountries?: string[];
 }
 
 /**
- * ArticlesFilters component exactly matching Create Sign In Page design
+ * ArticlesFilters component driven by dynamic server-side data.
  */
 export default function ArticlesFilters({
     searchQuery,
@@ -21,8 +22,15 @@ export default function ArticlesFilters({
     categoryFilter,
     setCategoryFilter,
     countryFilter,
-    setCountryFilter
+    setCountryFilter,
+    availableCategories = [],
+    availableCountries = []
 }: ArticlesFiltersProps) {
+    // Exclude "Restaurant" from categories as requested
+    const filteredCategories = availableCategories.filter(
+        (cat) => cat.toLowerCase() !== 'restaurant' && cat.toLowerCase() !== 'restaurants'
+    );
+
     return (
         <div className="flex items-center gap-4 p-5 border-b border-[#e5e7eb] bg-white">
             <div className="flex-1 relative">
@@ -41,9 +49,9 @@ export default function ArticlesFilters({
                     onChange={(e) => setCategoryFilter(e.target.value)}
                     className="w-full h-[50px] pl-3 pr-10 border border-[#d1d5db] rounded-[8px] text-[16px] text-[#111827] bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:border-transparent tracking-[-0.5px] cursor-pointer"
                 >
-                    <option value="">All Category</option>
-                    {Categories.filter(c => c.id !== 'All').map((cat) => (
-                        <option key={cat.id} value={cat.label}>{cat.label}</option>
+                    <option value="">All Categories</option>
+                    {filteredCategories.map((cat) => (
+                        <option key={cat} value={cat}>{cat}</option>
                     ))}
                 </select>
                 <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#9ca3af] pointer-events-none" />
@@ -55,8 +63,8 @@ export default function ArticlesFilters({
                     className="w-full h-[50px] pl-3 pr-10 border border-[#d1d5db] rounded-[8px] text-[16px] text-[#111827] bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:border-transparent tracking-[-0.5px] cursor-pointer"
                 >
                     <option value="">All Countries</option>
-                    {Countries.filter(c => c.id !== 'Global').map((country) => (
-                        <option key={country.id} value={country.id}>{country.label}</option>
+                    {availableCountries.map((country) => (
+                        <option key={country} value={country}>{country}</option>
                     ))}
                 </select>
                 <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#9ca3af] pointer-events-none" />

--- a/server/app/Services/RedisArticleService.php
+++ b/server/app/Services/RedisArticleService.php
@@ -118,10 +118,12 @@ class RedisArticleService
 
         $results = [];
         foreach ($articleIds as $id) {
-            if (count($results) >= $limit) break;
+            if (count($results) >= $limit)
+                break;
 
             $article = $this->getArticle($id);
-            if (!$article) continue;
+            if (!$article)
+                continue;
 
             // Apply search filter (title/content)
             if (!empty($search)) {
@@ -175,11 +177,17 @@ class RedisArticleService
         foreach ($keys as $key) {
             // Remove any Redis database prefix (e.g., "laravel_database_")
             $cleanKey = preg_replace('/^.*?homesph:/', 'homesph:', $key);
+
+            // Skip restaurant-specific indices
+            if (str_ends_with($cleanKey, ':restaurants')) {
+                continue;
+            }
+
             $name = str_replace("{$this->prefix}country:", '', $cleanKey);
             $name = str_replace('_', ' ', $name);
             $name = ucwords($name);
             $count = Redis::scard($key);
-            
+
             $countries[] = [
                 'name' => $name,
                 'count' => $count
@@ -203,11 +211,17 @@ class RedisArticleService
         foreach ($keys as $key) {
             // Remove any Redis database prefix
             $cleanKey = preg_replace('/^.*?homesph:/', 'homesph:', $key);
+
+            // Skip restaurant-specific indices
+            if (str_ends_with($cleanKey, ':restaurants')) {
+                continue;
+            }
+
             $name = str_replace("{$this->prefix}category:", '', $cleanKey);
             $name = str_replace('_', ' ', $name);
             $name = ucwords($name);
             $count = Redis::scard($key);
-            
+
             $categories[] = [
                 'name' => $name,
                 'count' => $count
@@ -257,8 +271,8 @@ class RedisArticleService
         // Re-index country if it changed
         $newCountry = $updated['country'] ?? $oldCountry;
         if ($oldCountry && $newCountry && $oldCountry !== $newCountry) {
-            $oldCountryKey = "{$this->prefix}country:".$this->slugify($oldCountry);
-            $newCountryKey = "{$this->prefix}country:".$this->slugify($newCountry);
+            $oldCountryKey = "{$this->prefix}country:" . $this->slugify($oldCountry);
+            $newCountryKey = "{$this->prefix}country:" . $this->slugify($newCountry);
             Redis::srem($oldCountryKey, $articleId);
             Redis::sadd($newCountryKey, $articleId);
         }
@@ -266,8 +280,8 @@ class RedisArticleService
         // Re-index category if it changed
         $newCategory = $updated['category'] ?? $oldCategory;
         if ($oldCategory && $newCategory && $oldCategory !== $newCategory) {
-            $oldCategoryKey = "{$this->prefix}category:".$this->slugify($oldCategory);
-            $newCategoryKey = "{$this->prefix}category:".$this->slugify($newCategory);
+            $oldCategoryKey = "{$this->prefix}category:" . $this->slugify($oldCategory);
+            $newCategoryKey = "{$this->prefix}category:" . $this->slugify($newCategory);
             Redis::srem($oldCategoryKey, $articleId);
             Redis::sadd($newCategoryKey, $articleId);
         }


### PR DESCRIPTION
## Overview
This PR improves the administrative article management experience by replacing hardcoded filter options with dynamic data from the database and Redis. It also ensures clear separation between news content and restaurant-specific scraper data.

## Key Changes

### 🎨 Frontend (Next.js)
- **Dynamic Filters**: [ArticlesFilters.tsx](cci:7://file:///home/kimperor/Documents/HomesPhNews/client/components/features/admin/articles/ArticlesFilters.tsx:0:0-0:0) now populates dropdowns using `availableCategories` and `availableCountries` provided by the API.
- **State Improvements**: Replaced hardcoded labels in [page.tsx](cci:7://file:///home/kimperor/Documents/HomesPhNews/client/app/admin/articles/page.tsx:0:0-0:0) with clean state logic to handle empty filter states correctly.
- **Visual Polish**: Removed all legacy imports from `@/app/data`.

### ⚙️ Backend (Laravel)
- **Unified Metadata**: Data from MySQL [categories](cci:1://file:///home/kimperor/Documents/HomesPhNews/Script/routes.py:337:0-364:66)/[countries](cci:1://file:///home/kimperor/Documents/HomesPhNews/Script/routes.py:323:0-334:68) tables is now merged with active Redis indices to ensure a comprehensive filter list.
- **Restaurant Exclusion**: Added explicit filtering in [ArticleController.php](cci:7://file:///home/kimperor/Documents/HomesPhNews/server/app/Http/Controllers/Api/Admin/ArticleController.php:0:0-0:0) to hide "Restaurant" categories from the news management view.
- **Redis Service Patch**: Updated [RedisArticleService.php](cci:7://file:///home/kimperor/Documents/HomesPhNews/server/app/Services/RedisArticleService.php:0:0-0:0) to ignore keys ending in `:restaurants`, preventing internal scraper indices (e.g., `Hong Kong:restaurants`) from leaking into public filter lists.

## Verification
- [x] Admin article dropdowns match the database entries.
- [x] Search and pagination work correctly with dynamic values.
- [x] "Restaurant" entries are successfully hidden from the news filters.
- [x] Internal Redis keys are no longer visible in the UI.