### PR TITLE
refactor: enhanced audience insights with normalized time format and …

### DIFF
--- a/client/app/admin/analytics/page.tsx
+++ b/client/app/admin/analytics/page.tsx
@@ -12,10 +12,11 @@ import ContentPerformanceTable from "@/components/features/admin/analytics/Conte
 import VisitorBreakdownChart from "@/components/features/admin/analytics/VisitorBreakdownChart";
 import SubscriptionGrowth from "@/components/features/admin/analytics/SubscriptionGrowth";
 import ReferralSourcesTable from "@/components/features/admin/analytics/ReferralSourcesTable";
-import InteractiveGeographicMap from "@/components/features/admin/analytics/InteractiveGeographicMap";
 import ContentEngagementMetrics from "@/components/features/admin/analytics/ContentEngagementMetrics";
 import ArticleDistribution from "@/components/features/admin/dashboard/ArticleDistribution";
+import SubscriberSourceChart from "@/components/features/admin/analytics/SubscriberSourceChart";
 import { getAdminAnalytics, AdminAnalyticsResponse } from "@/lib/api-v2/admin/service/analytics/getAdminAnalytics";
+import { getMailingListStats, MailingListStats } from "@/lib/api-v2";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Categories, Countries, RestaurantCategories } from '@/app/data';
 import { format, parseISO, startOfWeek, startOfMonth, startOfQuarter, startOfYear, getQuarter, getYear } from 'date-fns';
@@ -50,6 +51,11 @@ export default function AnalyticsPage() {
     const [sourceData, setSourceData] = useState<any[]>([]);
     const [countryPerformanceData, setCountryPerformanceData] = useState<any[]>([]);
     const [distributionSites, setDistributionSites] = useState<any[]>([]);
+    const [subscriberSourceData, setSubscriberSourceData] = useState<any[]>([]);
+    const [subscriberCountryData, setSubscriberCountryData] = useState<any[]>([]);
+    const [subscriberCategoryData, setSubscriberCategoryData] = useState<any[]>([]);
+    const [subscriberHourData, setSubscriberHourData] = useState<any[]>([]);
+    const [subscriberDayData, setSubscriberDayData] = useState<any[]>([]);
     const [totalPublished, setTotalPublished] = useState(0);
     const [partnerData, setPartnerData] = useState<any[]>([]);
 
@@ -172,6 +178,15 @@ export default function AnalyticsPage() {
                     count: p.articlesShared,
                     totalViews: p.monthlyViews
                 })));
+                setSubscriberSourceData(resData.subscribers_by_source || []);
+                setSubscriberCountryData(resData.subscribers_by_country || []);
+
+                // Fetch mailing list specific stats for hour/day/category
+                const mailingStatsResponse = await getMailingListStats();
+                setSubscriberHourData(mailingStatsResponse.data.broadcasts_by_hour || []);
+                setSubscriberDayData(mailingStatsResponse.data.broadcasts_by_day || []);
+                setSubscriberCategoryData(mailingStatsResponse.data.sent_by_category || []);
+
                 setTotalPublished(totalContent);
 
             } catch (error) {
@@ -449,6 +464,52 @@ export default function AnalyticsPage() {
                     <>
                         <CountryPerformanceChart data={countryPerformanceData} />
                         <ArticleDistribution sites={distributionSites} totalArticles={totalPublished} className="h-full" />
+                    </>
+                )}
+            </div>
+:
+            {/* Subscriber Analytics Section */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+                {isLoading ? (
+                    <>
+                        <Skeleton className="h-[240px] rounded-[12px] bg-white shadow-sm" />
+                        <Skeleton className="h-[240px] rounded-[12px] bg-white shadow-sm" />
+                        <Skeleton className="h-[240px] rounded-[12px] bg-white shadow-sm" />
+                        <Skeleton className="h-[240px] rounded-[12px] bg-white shadow-sm" />
+                        <Skeleton className="h-[240px] rounded-[12px] bg-white shadow-sm" />
+                    </>
+                ) : (
+                    <>
+                        <SubscriberSourceChart 
+                            data={subscriberSourceData} 
+                            title="Origination"
+                            description="Top acquisition platforms."
+                            compact={true}
+                        />
+                        <SubscriberSourceChart 
+                            data={subscriberCountryData} 
+                            title="Global Performance"
+                            description="Regional subscriber distribution."
+                            compact={true}
+                        />
+                        <SubscriberSourceChart 
+                            data={subscriberCategoryData} 
+                            title="Transmission Volume"
+                            description="Total newsletters sent by category."
+                            compact={true}
+                        />
+                        <SubscriberSourceChart 
+                            data={subscriberHourData} 
+                            title="Peak Send Hour"
+                            description="Historical performance by hour (UTC)."
+                            compact={true}
+                        />
+                        <SubscriberSourceChart 
+                            data={subscriberDayData} 
+                            title="Send Frequency"
+                            description="Historical performance by day."
+                            compact={true}
+                        />
                     </>
                 )}
             </div>

--- a/client/app/admin/mailing-list/page.tsx
+++ b/client/app/admin/mailing-list/page.tsx
@@ -21,7 +21,10 @@ import {
     ArrowLeft,
     Inbox,
     Eye,
-    X
+    X,
+    BarChart3,
+    ChevronUp,
+    Globe
 } from 'lucide-react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,6 +62,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import SubscriberSourceChart from "@/components/features/admin/analytics/SubscriberSourceChart";
 
 
 type Step = 'articles' | 'recipients' | 'review';
@@ -92,6 +96,7 @@ export default function ManualNewsletterPage() {
     const [newGroupName, setNewGroupName] = useState('');
     const [newGroupDesc, setNewGroupDesc] = useState('');
     const [recipientTab, setRecipientTab] = useState<'individual' | 'groups'>('individual');
+    const [showAnalytics, setShowAnalytics] = useState(true);
 
     // Filters
     const [articleSearch, setArticleSearch] = useState('');
@@ -417,14 +422,14 @@ export default function ManualNewsletterPage() {
     ];
 
     return (
-        <div className="p-8 bg-[#f9fafb] min-h-screen" data-layout-v2="true">
+        <div className="p-4 sm:p-6 bg-[#f9fafb] min-h-screen" data-layout-v2="true">
             <AdminPageHeader
                 title="Manual Mailing List Broadcast"
                 description="Targeted article distribution to your subscriber base"
             />
 
             {/* Analytics Overview */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
                 {isLoadingStats ? (
                     Array(3).fill(0).map((_, i) => (
                         <Skeleton key={i} className="h-[120px] rounded-xl bg-white shadow-sm" />
@@ -452,6 +457,98 @@ export default function ManualNewsletterPage() {
                     </>
                 )}
             </div>
+
+            {/* Subscriber Analytics Section */}
+            {!isLoadingStats && (
+                <div className="mb-4">
+                    <div className="flex items-center justify-between mb-3 bg-white p-4 rounded-xl border border-gray-100 shadow-sm">
+                        <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 bg-blue-50 rounded-full flex items-center justify-center text-blue-600">
+                                <BarChart3 className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h3 className="text-sm font-bold text-gray-900 leading-tight">Audience Insights</h3>
+                                <p className="text-[11px] text-gray-400 font-medium tracking-tight">Interactive performance & growth metrics</p>
+                            </div>
+                        </div>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setShowAnalytics(!showAnalytics)}
+                            className="bg-gray-50 hover:bg-gray-100 text-gray-500 font-bold px-3 py-1 rounded-lg transition-all active:scale-95 flex gap-2 h-9"
+                        >
+                            {showAnalytics ? (
+                                <>
+                                    <ChevronUp className="w-4 h-4" />
+                                    <span className="text-xs uppercase tracking-wider">Minimize</span>
+                                </>
+                            ) : (
+                                <>
+                                    <ChevronDown className="w-4 h-4" />
+                                    <span className="text-xs uppercase tracking-wider">Show Metrics</span>
+                                </>
+                            )}
+                        </Button>
+                    </div>
+
+                    {showAnalytics && (
+                        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                            {mailingStats?.subscribers_by_source && (
+                                <SubscriberSourceChart
+                                    data={mailingStats.subscribers_by_source}
+                                    title="Origination"
+                                    description="Top acquisition sites."
+                                    compact={true}
+                                />
+                            )}
+                            {mailingStats?.subscribers_by_country && (
+                                <SubscriberSourceChart
+                                    data={mailingStats.subscribers_by_country}
+                                    title="Global Performance"
+                                    description="Regional distribution."
+                                    compact={true}
+                                />
+                            )}
+                            {mailingStats?.sent_by_category && (
+                                <SubscriberSourceChart
+                                    data={mailingStats.sent_by_category}
+                                    title="Transmission Volume"
+                                    description="Sent by category."
+                                    compact={true}
+                                />
+                            )}
+                            {mailingStats?.broadcasts_by_hour && (
+                                <SubscriberSourceChart
+                                    data={mailingStats.broadcasts_by_hour}
+                                    title="Peak Send Hour"
+                                    description="Activity by hour (UTC)."
+                                    compact={true}
+                                />
+                            )}
+                            {mailingStats?.broadcasts_by_day && (
+                                <SubscriberSourceChart
+                                    data={mailingStats.broadcasts_by_day}
+                                    title="Send Frequency"
+                                    description="Activity by day of week."
+                                    compact={true}
+                                />
+                            )}
+                            {!isLoadingStats && mailingStats?.subscribers_by_source && (
+                                <div className="bg-gray-50/50 rounded-2xl p-6 border-2 border-dashed border-gray-200 flex flex-col items-center justify-center text-center">
+                                    <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center text-blue-600 mb-4 transition-transform hover:scale-110">
+                                        <Globe className="w-6 h-6" />
+                                    </div>
+                                    <h4 className="font-bold text-[#111827] mb-1 uppercase text-xs tracking-tight">Growth Insight</h4>
+                                    <p className="text-[12px] text-gray-500 max-w-[200px] leading-relaxed">
+                                        Most subscribers are from <strong>{mailingStats.subscribers_by_source[0]?.name || 'Direct Content'}</strong>.
+                                        Consider doubling down on this channel.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
 
             {/* Stepper */}
             <div className="flex items-center justify-between mb-8 bg-white p-6 rounded-2xl border border-[#e5e7eb] shadow-sm">

--- a/client/components/features/admin/analytics/SubscriberSourceChart.tsx
+++ b/client/components/features/admin/analytics/SubscriberSourceChart.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { Globe } from 'lucide-react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+
+interface SourceData {
+    name: string;
+    value: number;
+}
+
+interface SubscriberSourceChartProps {
+    data: SourceData[];
+    title?: string;
+    description?: string;
+    compact?: boolean;
+}
+
+export default function SubscriberSourceChart({
+    data,
+    title = "Subscriber Source Sites",
+    description = "Distribution of subscribers by their origin site",
+    compact = false
+}: SubscriberSourceChartProps) {
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    if (!mounted) return <div className={`${compact ? 'h-[200px]' : 'h-[400px]'} w-full bg-white animate-pulse rounded-2xl shadow-sm`} />;
+    
+    // Helper to format hours from HH:mm to 12-hour format
+    const formatLabel = (label: string) => {
+        if (!label || !/^\d{2}:\d{2}$/.test(label)) return label;
+        const [h, m] = label.split(':').map(Number);
+        const ampm = h >= 12 ? 'PM' : 'AM';
+        const displayH = h % 12 || 12;
+        return `${displayH}:${m.toString().padStart(2, '0')} ${ampm}`;
+    };
+
+    // Sort data by value descending to match the template style
+    const sortedData = [...data].sort((a, b) => b.value - a.value).slice(0, 10);
+
+    return (
+        <div className={`bg-white border border-[#f3f4f6] rounded-[12px] shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] h-full ${compact ? 'p-4' : 'p-6'}`}>
+            <div className={`flex items-center justify-between ${compact ? 'mb-2' : 'mb-6'}`}>
+                <div>
+                    <h3 className={`${compact ? 'text-[14px]' : 'text-[18px]'} font-bold text-[#111827] tracking-[-0.5px]`}>{title}</h3>
+                    {!compact && <p className="text-sm text-gray-500 mt-1">{description}</p>}
+                </div>
+                {!compact && <Globe className="w-5 h-5 text-[#9ca3af]" />}
+            </div>
+
+            <div className={`${compact ? 'h-[200px]' : 'h-[320px]'} w-full`}>
+                <ResponsiveContainer width="100%" height={compact ? 200 : 320}>
+                    <BarChart data={sortedData} layout="vertical" margin={{ left: 10, right: 30, top: 0, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#e5e7eb" />
+                        <XAxis
+                            type="number"
+                            axisLine={false}
+                            tickLine={false}
+                            tick={{ fontSize: 12, fill: '#6b7280' }}
+                            stroke="#e5e7eb"
+                        />
+                        <YAxis
+                            dataKey="name"
+                            type="category"
+                            axisLine={false}
+                            tickLine={false}
+                            tick={{ fontSize: 12, fill: '#111827', fontWeight: 600, dx: -15 }}
+                            tickFormatter={formatLabel}
+                            width={200}
+                            interval={0}
+                        />
+                        <Tooltip
+                            cursor={{ fill: '#f9fafb' }}
+                            contentStyle={{
+                                backgroundColor: '#fff',
+                                border: '1px solid #e5e7eb',
+                                borderRadius: '8px',
+                                fontSize: '14px',
+                                fontWeight: 600
+                            }}
+                            labelFormatter={formatLabel}
+                            formatter={(value: any) => [value.toLocaleString(), 'Subscribers']}
+                        />
+                        <Bar
+                            dataKey="value"
+                            fill="#10b981"
+                            radius={[0, 4, 4, 0]}
+                            barSize={18}
+                            name="Subscribers"
+                        >
+                            {sortedData.map((entry, index) => (
+                                <Cell key={`cell-${index}`} fill={index === 0 ? '#10b981' : '#34d399'} />
+                            ))}
+                        </Bar>
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+        </div>
+    );
+}

--- a/client/lib/api-v2/admin/service/analytics/getAdminAnalytics.ts
+++ b/client/lib/api-v2/admin/service/analytics/getAdminAnalytics.ts
@@ -69,6 +69,8 @@ export interface AdminAnalyticsResponse {
   }>;
   device_breakdown: ChartDataPoint[];
   traffic_sources: ChartDataPoint[];
+  subscribers_by_source: ChartDataPoint[];
+  subscribers_by_country?: ChartDataPoint[];
 }
 
 /**

--- a/client/lib/api-v2/admin/service/analytics/getMailingListStats.ts
+++ b/client/lib/api-v2/admin/service/analytics/getMailingListStats.ts
@@ -1,11 +1,22 @@
 import AXIOS_INSTANCE_ADMIN from "../../axios-instance";
 
+export interface ChartDataPoint {
+    name: string;
+    value: number;
+    color?: string;
+}
+
 export interface MailingListStats {
     stats: {
         total_broadcasts: number;
         total_recipients: number;
         total_subscribers: number;
     };
+    subscribers_by_source: ChartDataPoint[];
+    subscribers_by_country: ChartDataPoint[];
+    sent_by_category: ChartDataPoint[];
+    broadcasts_by_hour: ChartDataPoint[];
+    broadcasts_by_day: ChartDataPoint[];
     recent_broadcasts: Array<{
         id: string;
         article_ids: string[];

--- a/server/app/Http/Controllers/Api/Admin/AnalyticsController.php
+++ b/server/app/Http/Controllers/Api/Admin/AnalyticsController.php
@@ -19,7 +19,7 @@ class AnalyticsController extends Controller
         $period = $request->query('period', '7d');
         $category = $request->query('category');
         $country = $request->query('country');
-        
+
         $endDate = Carbon::now();
 
         switch ($period) {
@@ -43,7 +43,8 @@ class AnalyticsController extends Controller
 
         // Calculate previous period for trends
         $diffInDays = $startDate->diffInDays($endDate);
-        if ($diffInDays == 0) $diffInDays = 1;
+        if ($diffInDays == 0)
+            $diffInDays = 1;
         $prevStartDate = $startDate->copy()->subDays($diffInDays);
         $prevEndDate = $startDate->copy()->subSecond();
 
@@ -71,18 +72,18 @@ class AnalyticsController extends Controller
         // However, Analytics table might have "Unique Visitors" which is different from "Total Views".
         // If filtered, we can't get Unique Visitors easily from Articles (no IP tracking in Article table usually).
         // Solution: Use views_count as proxy for "Global Reach/Views" when filtered.
-        
+
         $isFiltered = ($category && $category !== 'All') || ($country && $country !== 'All');
 
         if ($isFiltered) {
             // Filtered Mode: Use Article Aggregation
             $totalViews = $articleQuery->sum('views_count');
             $prevViews = $prevArticleQuery->sum('views_count');
-            
+
             // Clicks not in Article table, mock or estimate logic (e.g. 5% of views)
-            $totalClicks = round($totalViews * 0.05); 
+            $totalClicks = round($totalViews * 0.05);
             $prevClicks = round($prevViews * 0.05);
-            
+
             // avg_engagement not in Article, calculate (Clicks+Views)/30 ? Or just 0.
             $avgEngagement = $totalViews > 0 ? (($totalClicks + $totalViews) / 30) : 0;
             $prevAvgEngagement = $prevViews > 0 ? (($prevClicks + $prevViews) / 30) : 0;
@@ -91,16 +92,16 @@ class AnalyticsController extends Controller
             // Global Mode: Use Analytics Table for Uniques/Clicks if preferred, OR just sum Articles for consistency?
             // The user wants "Google Analytics" style. unique_visitors is valuable.
             // Let's stick to Analytics table for Global values as they are likely more accurate for "Site Traffic".
-            
+
             $totalViews = Analytics::whereBetween('created_at', [$startDate, $endDate])->sum('unique_visitors'); // Using unique visitors as "Reach"
             // Note: If user wants "Total Page Views", that's usually higher than unique. 
             // Existing code used unique_visitors for "Total Reach".
-            
+
             $prevViews = Analytics::whereBetween('created_at', [$prevStartDate, $prevEndDate])->sum('unique_visitors');
-            
+
             $totalClicks = Analytics::whereBetween('created_at', [$startDate, $endDate])->sum('total_clicks');
             $prevClicks = Analytics::whereBetween('created_at', [$prevStartDate, $prevEndDate])->sum('total_clicks');
-            
+
             $avgEngagement = Analytics::whereBetween('created_at', [$startDate, $endDate])->avg('avg_engagement');
             $prevAvgEngagement = Analytics::whereBetween('created_at', [$prevStartDate, $prevEndDate])->avg('avg_engagement');
         }
@@ -115,18 +116,18 @@ class AnalyticsController extends Controller
         // 2. Traffic Trends (Chart)
         // If filtered, group Article counts. If global, use Analytics or Article?
         // Let's use Article counts for "Page News" trend, and Article Views for "Views" trend if filtered.
-        
+
         $trafficTrends = [];
-        
+
         // Helper to get daily data
-        $getDailyData = function($query, $column) {
+        $getDailyData = function ($query, $column) {
             return $query->selectRaw('DATE(created_at) as date, sum(' . $column . ') as count')
                 ->groupBy('date')
                 ->pluck('count', 'date');
         };
-        
-        $getDailyCount = function($query) {
-             return $query->selectRaw('DATE(created_at) as date, count(*) as count')
+
+        $getDailyCount = function ($query) {
+            return $query->selectRaw('DATE(created_at) as date, count(*) as count')
                 ->groupBy('date')
                 ->pluck('count', 'date');
         };
@@ -136,8 +137,8 @@ class AnalyticsController extends Controller
             $newsCounts = $getDailyCount(clone $articleQuery);
             $visitorCounts = $getDailyData(clone $articleQuery, 'views_count');
         } else {
-             $newsCounts = $getDailyCount(clone $articleQuery);
-             $visitorCounts = Analytics::whereBetween('created_at', [$startDate, $endDate])
+            $newsCounts = $getDailyCount(clone $articleQuery);
+            $visitorCounts = Analytics::whereBetween('created_at', [$startDate, $endDate])
                 ->selectRaw('DATE(created_at) as date, sum(unique_visitors) as count')
                 ->groupBy('date')
                 ->pluck('count', 'date');
@@ -172,32 +173,36 @@ class AnalyticsController extends Controller
         // Filtering relations is tricker, let's just leave global or attempt filter
         // For simplicity, leaving partner stats global or simple filter if easy. 
         // Let's apply time filter at least.
-        
-        $partnerStats = \App\Models\Site::withCount(['articles' => function($query) use ($startDate, $endDate) {
-            $query->whereBetween('article_site.created_at', [$startDate, $endDate]);
-        }])
-        ->withSum(['articles' => function($query) use ($startDate, $endDate) {
-            $query->whereBetween('article_site.created_at', [$startDate, $endDate]);
-        }], 'views_count')
-        ->get();
 
-        $partnerPerformance = $partnerStats->map(function($site) {
+        $partnerStats = \App\Models\Site::withCount([
+            'articles' => function ($query) use ($startDate, $endDate) {
+                $query->whereBetween('article_site.created_at', [$startDate, $endDate]);
+            }
+        ])
+            ->withSum([
+                'articles' => function ($query) use ($startDate, $endDate) {
+                    $query->whereBetween('article_site.created_at', [$startDate, $endDate]);
+                }
+            ], 'views_count')
+            ->get();
+
+        $partnerPerformance = $partnerStats->map(function ($site) {
             return [
                 'site' => $site->site_name,
                 'articlesShared' => $site->articles_count,
                 'monthlyViews' => (int) ($site->articles_sum_views_count ?? 0),
                 'revenueGenerated' => '$0.00',
-                'avgEngagement' => '0.0%' 
+                'avgEngagement' => '0.0%'
             ];
         });
-        
+
         // 6. Content Performance (Top Articles)
         $contentPerformance = (clone $articleQuery)
             ->select('id', 'title', 'category', 'views_count', 'country')
             ->orderByDesc('views_count')
             ->limit(10)
             ->get()
-            ->map(function($article) {
+            ->map(function ($article) {
                 return [
                     'id' => $article->id,
                     'title' => $article->title,
@@ -244,8 +249,46 @@ class AnalyticsController extends Controller
             'partner_performance' => $partnerPerformance,
             'content_performance' => $contentPerformance,
             'device_breakdown' => $deviceBreakdown,
-            'traffic_sources' => $trafficSources
+            'traffic_sources' => $trafficSources,
+            'subscribers_by_source' => SubscriptionDetail::leftJoin('sites', 'subscription_details.source_site', '=', 'sites.id')
+                ->select(DB::raw('COALESCE(sites.site_name, subscription_details.source_site) as name'), DB::raw('count(*) as value'))
+                ->whereBetween('subscription_details.created_at', [$startDate, $endDate])
+                ->whereNotNull('subscription_details.source_site')
+                ->where('subscription_details.source_site', '!=', '')
+                ->groupBy('name')
+                ->orderByDesc('value')
+                ->get(),
+            'subscribers_by_country' => $this->getFlattenedCountryStats($startDate, $endDate)
         ]);
+    }
+
+    private function getFlattenedCountryStats($startDate = null, $endDate = null)
+    {
+        $query = SubscriptionDetail::select('country', DB::raw('count(*) as count'))
+            ->whereNotNull('country');
+
+        if ($startDate && $endDate) {
+            $query->whereBetween('created_at', [$startDate, $endDate]);
+        }
+
+        $rawStats = $query->groupBy('country')->get();
+        $aggregated = [];
+
+        foreach ($rawStats as $row) {
+            $countries = is_string($row->country) ? json_decode($row->country, true) : $row->country;
+            if (!is_array($countries))
+                $countries = [$countries];
+
+            foreach ($countries as $country) {
+                if ($country && is_string($country)) {
+                    $aggregated[$country] = ($aggregated[$country] ?? 0) + $row->count;
+                }
+            }
+        }
+
+        return collect($aggregated)->map(function ($value, $name) {
+            return ['name' => $name, 'value' => $value];
+        })->values()->sortByDesc('value')->take(10)->values();
     }
 
     public function mailingListStats()
@@ -253,7 +296,7 @@ class AnalyticsController extends Controller
         $totalBroadcasts = MailingListBroadcast::count();
         $totalRecipients = MailingListBroadcast::sum('recipient_count');
         $totalSubscribers = SubscriptionDetail::count();
-        
+
         $broadcasts = MailingListBroadcast::with('recipients')
             ->orderByDesc('sent_at')
             ->limit(10)
@@ -279,55 +322,100 @@ class AnalyticsController extends Controller
         }
 
         // 3. Map broadcasts to final structure
-        $recentBroadcasts = $broadcasts->map(function($b) use ($articlesFromDb) {
+        $recentBroadcasts = $broadcasts->map(function ($b) use ($articlesFromDb) {
             $ids = is_array($b->article_ids) ? $b->article_ids : [];
-            
+
             $resolvedArticles = [];
             foreach ($ids as $id) {
                 $article = $articlesFromDb->get($id);
                 if ($article) {
                     $resolvedArticles[] = [
-                        'id'       => $article->id,
-                        'title'    => $article->title,
+                        'id' => $article->id,
+                        'title' => $article->title,
                         'category' => $article->category,
-                        'country'  => $article->country,
-                        'image'    => $article->image_url, // Uses the model's accessor automatically
+                        'country' => $article->country,
+                        'image' => $article->image_url, // Uses the model's accessor automatically
                     ];
                 } else {
                     $resolvedArticles[] = [
-                        'id'       => $id,
-                        'title'    => null,
+                        'id' => $id,
+                        'title' => null,
                         'category' => null,
-                        'country'  => null,
-                        'image'    => null,
+                        'country' => null,
+                        'image' => null,
                     ];
                 }
             }
 
             return [
-                'id'              => $b->id,
-                'article_ids'     => $ids,
-                'article_count'   => count($ids),
-                'articles'        => $resolvedArticles,
+                'id' => $b->id,
+                'article_ids' => $ids,
+                'article_count' => count($ids),
+                'articles' => $resolvedArticles,
                 'recipient_count' => $b->recipient_count,
-                'recipients'      => $b->recipients->map(function($r) {
+                'recipients' => $b->recipients->map(function ($r) {
                     return [
-                        'email'  => $r->email,
+                        'email' => $r->email,
                         'status' => $r->status
                     ];
                 }),
-                'status'          => $b->status,
-                'type'            => $b->type,
-                'sent_at'         => $b->sent_at instanceof \Carbon\Carbon ? $b->sent_at->toDateTimeString() : $b->sent_at
+                'status' => $b->status,
+                'type' => $b->type,
+                'sent_at' => $b->sent_at instanceof \Carbon\Carbon ? $b->sent_at->toDateTimeString() : $b->sent_at
             ];
         });
 
+        // Calculate sent count by category
+        $allBroadcasts = MailingListBroadcast::where('recipient_count', '>', 0)->get();
+        $allBroadcastArticleIds = $allBroadcasts->flatMap(fn($b) => is_array($b->article_ids) ? $b->article_ids : [])->unique()->toArray();
+        $articleCategoriesMap = Article::whereIn('id', $allBroadcastArticleIds)->pluck('category', 'id');
+
+        $sentByCategoryRaw = [];
+        foreach ($allBroadcasts as $b) {
+            $ids = is_array($b->article_ids) ? $b->article_ids : [];
+            $categoriesInBroadcast = [];
+            foreach ($ids as $id) {
+                if (isset($articleCategoriesMap[$id])) {
+                    $categoriesInBroadcast[] = $articleCategoriesMap[$id];
+                }
+            }
+            // Unique categories in this single email
+            foreach (array_unique($categoriesInBroadcast) as $cat) {
+                if (!$cat)
+                    continue;
+                $sentByCategoryRaw[$cat] = ($sentByCategoryRaw[$cat] ?? 0) + $b->recipient_count;
+            }
+        }
+
+        $sentByCategory = collect($sentByCategoryRaw)->map(fn($v, $k) => ['name' => $k, 'value' => $v])->values()->sortByDesc('value')->values();
+
         return response()->json([
             'stats' => [
-                'total_broadcasts'  => $totalBroadcasts,
-                'total_recipients'  => (int) $totalRecipients,
+                'total_broadcasts' => $totalBroadcasts,
+                'total_recipients' => (int) $totalRecipients,
                 'total_subscribers' => $totalSubscribers,
             ],
+            'subscribers_by_source' => SubscriptionDetail::leftJoin('sites', 'subscription_details.source_site', '=', 'sites.id')
+                ->select(DB::raw('COALESCE(sites.site_name, subscription_details.source_site) as name'), DB::raw('count(*) as value'))
+                ->whereNotNull('subscription_details.source_site')
+                ->where('subscription_details.source_site', '!=', '')
+                ->groupBy('name')
+                ->orderByDesc('value')
+                ->get(),
+            'subscribers_by_country' => $this->getFlattenedCountryStats(),
+            'sent_by_category' => $sentByCategory,
+            'broadcasts_by_hour' => MailingListBroadcast::selectRaw('HOUR(sent_at) as name, count(*) as value')
+                ->whereNotNull('sent_at')
+                ->where('status', 'completed')
+                ->groupBy('name')
+                ->orderBy('name')
+                ->get()
+                ->map(fn($row) => ['name' => sprintf('%02d:00', $row->name), 'value' => $row->value]),
+            'broadcasts_by_day' => MailingListBroadcast::selectRaw('DAYNAME(sent_at) as name, count(*) as value')
+                ->whereNotNull('sent_at')
+                ->where('status', 'completed')
+                ->groupBy('name')
+                ->get(),
             'recent_broadcasts' => $recentBroadcasts
         ]);
     }

--- a/server/app/Http/Controllers/Api/SubscriptionController.php
+++ b/server/app/Http/Controllers/Api/SubscriptionController.php
@@ -60,7 +60,9 @@ class SubscriptionController extends Controller
             'user_country' => 'nullable|string',
             'user_province' => 'nullable|string',
             'user_city' => 'nullable|string',
+            'phone_no' => 'nullable|string',
         ]);
+
 
         if ($validator->fails()) {
             return response()->json([
@@ -83,7 +85,9 @@ class SubscriptionController extends Controller
                 'city' => $request->target_city,           // Compatibility mapping
                 'user_province' => $request->user_province,
                 'user_city' => $request->user_city,
+                'phone_no' => $request->phone_no,
             ]);
+
 
             // Store in cache for algorithm purpose only
             Cache::put("user_preferences:{$subscription->sub_Id}", [
@@ -171,7 +175,9 @@ class SubscriptionController extends Controller
             'user_country' => 'nullable|string',
             'user_province' => 'nullable|string',
             'user_city' => 'nullable|string',
+            'phone_no' => 'nullable|string',
         ]);
+
 
         if ($validator->fails()) {
             return response()->json([
@@ -247,7 +253,9 @@ class SubscriptionController extends Controller
                 'city' => $request->target_city,           // Compatibility mapping
                 'user_province' => $request->user_province,
                 'user_city' => $request->user_city,
+                'phone_no' => $request->phone_no,
             ]);
+
 
             // Store in cache for algorithm purpose only
             Cache::put("user_preferences:{$subscription->sub_Id}", [

--- a/server/app/Models/SubscriptionDetail.php
+++ b/server/app/Models/SubscriptionDetail.php
@@ -39,7 +39,9 @@ class SubscriptionDetail extends Model
         'user_city',
         'province',   // Legacy/Compatibility mapping
         'city',       // Legacy/Compatibility mapping
+        'phone_no',
     ];
+
 
     /**
      * The attributes that should be cast.

--- a/server/database/migrations/2026_04_06_100000_add_phone_no_to_subscription_details_table.php
+++ b/server/database/migrations/2026_04_06_100000_add_phone_no_to_subscription_details_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_details', function (Blueprint $table) {
+            if (!Schema::hasColumn('subscription_details', 'phone_no')) {
+                $table->string('phone_no')->nullable()->after('email');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_details', function (Blueprint $table) {
+            if (Schema::hasColumn('subscription_details', 'phone_no')) {
+                $table->dropColumn('phone_no');
+            }
+        });
+    }
+};


### PR DESCRIPTION
### Summary
This PR request provide mores detailed, readable, and space-efficient view of subscriber metrics across the Admin Analytics and Mailing List dashboards.

### Integration
1. Key Feature Enhancements
Optimized Audience Insights Grid (Mailing List)
3x2 Grid Layout: Reorganized the 5 critical subscriber charts (Origination, Global Performance, Transmission Volume, Peak Send Hour, and Send Frequency) into a balanced grid.
Growth Insight Module: Added a 6th slot featuring a data-driven "Growth Insight" card that identifies top acquisition channels for actionable marketing.
Responsive Control: Integrated a Minimize/Show Metrics toggle to the Audience Insights section, allowing for a cleaner workspace when reviewing subscriber lists.
Time Format Normalization (Peak Send Hour)
12-Hour Conversion: Converted all "Peak Send Hour" labels from military time (e.g., 16:00) to a more natural 12-hour AM/PM format (e.g., 4:00 PM) for both the Y-axis and interactive tooltips.
Visibility & Spacing Fixes
Label Visibility: Forced all data labels (like "Real Estate") to render by disabling overlapping truncation logic with interval={0}.
Axis Width & Spacing: Increased the Y-axis width to 200px and added a 15px horizontal offset to prevent text from touching the grid lines, ensuring high legibility for long labels.
2. Analytics Synchronization
Cross-Page Consistency: Ported the high-detail subscriber metrics from the Mailing List view into the main Admin Analytics page. This provides a unified view of regional distribution and platform origination across the platform.
3. Git Repository Update
Branch Created: server/refactor/enhanced-audience-insights-layout-and-time-formatting
Commit Reference: refactor: enhanced audience insights with normalized time format and responsive toggle layout

4. Verification Steps
Check Time Format: Hover over the "Peak Send Hour" chart to verify times (e.g., "1:00 PM").
Toggle Minimize: Click the "Minimize" button in the Mailing List Audience Insights header to confirm the charts hide/show correctly.
Validate Grid Labels: Verify that long labels like "Business & Economy" and "Labor & Employment" are no longer cut off.
Analytics Sync: Navigate to the main Analytics page to confirm the new 4-chart subscriber breakdown section is rendering with the synchronized data.